### PR TITLE
changes based on full code review

### DIFF
--- a/evm/src/assets/TbrDispatcher.sol
+++ b/evm/src/assets/TbrDispatcher.sol
@@ -36,12 +36,14 @@ abstract contract TbrDispatcher is RawDispatcher, TbrGovernance, TbrUser {
 
       if (command == TRANSFER_TOKEN_WITH_RELAY_ID) {
         uint256 fee; uint256 gasTokenSent;
-        (fee, gasTokenSent, offset) = _transferTokenWithRelay(data, offset, senderRefund, commandIndex);
+        (fee, gasTokenSent, offset) =
+          _transferTokenWithRelay(data, offset, senderRefund, commandIndex);
         fees += fee;
         senderRefund -= fee + gasTokenSent;
       } else if (command == TRANSFER_GAS_TOKEN_WITH_RELAY_ID) {
         uint256 fee; uint256 gasTokenSent;
-        (fee, gasTokenSent, offset) = _transferGasTokenWithRelay(data, offset, senderRefund, commandIndex);
+        (fee, gasTokenSent, offset) =
+          _transferGasTokenWithRelay(data, offset, senderRefund, commandIndex);
         fees += fee;
         senderRefund -= fee + gasTokenSent;
       } else if (command == COMPLETE_TRANSFER_ID) {

--- a/evm/src/assets/TbrGovernance.sol
+++ b/evm/src/assets/TbrGovernance.sol
@@ -83,10 +83,10 @@ abstract contract TbrGovernance is TbrBase, ProxyBase {
     else
       revert NotAuthorized();
 
-    uint8 commandCount;
+    uint commandCount;
     (commandCount, offset) = commands.asUint8CdUnchecked(offset);
 
-    for (uint8 i = 0; i < commandCount; i++) {
+    for (uint i = 0; i < commandCount; ++i) {
       uint8 command;
       (command, offset) = commands.asUint8CdUnchecked(offset);
 


### PR DESCRIPTION
fixes:
* addPeer now sets canonical peer if no peer has been registered (otherwise admins can never register new chains without help of owner)
* [inconsisten sort order](https://github.com/XLabs/arbitrary-token-transfers/blob/2152803bd14122e818e372850a2483eeb388b316/evm/src/assets/TbrUser.sol#L322-L323) - everywhere else it is fee before wormhole fee, which also gave rise to a [bug](https://github.com/XLabs/arbitrary-token-transfers/commit/1c5934a0beb3c2ae806895855a59169e6f875d28) (that got fixed suboptimally)