### PR TITLE
fix: sets solana tests to `NodeNext` modules

### DIFF
--- a/solana/tsconfig.json
+++ b/solana/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "module": "esnext",
-    "moduleResolution": "node",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "outDir": "ts-build"
   },
   "include": ["tests", "programs/token-bridge-relayer/*.json"],


### PR DESCRIPTION
Attempt to fix the import issues we're having.