### PR TITLE
EVM: a few fixes

### DIFF
--- a/evm/src/assets/TbrUser.sol
+++ b/evm/src/assets/TbrUser.sol
@@ -482,6 +482,9 @@ abstract contract TbrUser is TbrBase {
       token = fromUniversalAddress(tokenOriginAddress);
     }
 
+    uint8 decimals = IERC20Metadata(token).decimals();
+    tokenAmount = deNormalizeAmount(tokenAmount, decimals);
+
     // If an unwrap is desired, unwrap and call recipient with full amount
     uint totalGasTokenAmount = gasDropoff;
     if (address(gasToken) == token && unwrapIntent && gasErc20TokenizationIsExplicit) {
@@ -599,7 +602,9 @@ library TokenBridgeVAAParser {
     dataOffset += _VAA_TOKEN_AMOUNT_SKIP;
     //we don't check the payload id because the sizes will mismatch in the end if it's not a
     //  payload 3 transfer
-    
+
+    // Note that the token amount is expressed in at most 8 decimals so
+    // you need to denormalize this amount before calling transfer functions on the token.
     (tokenAmount, dataOffset) = data.asUint256CdUnchecked(dataOffset);
     (tokenOriginAddress, dataOffset) = data.asBytes32CdUnchecked(dataOffset);
     (tokenOriginChain, dataOffset) = data.asUint16CdUnchecked(dataOffset);

--- a/evm/src/assets/TbrUser.sol
+++ b/evm/src/assets/TbrUser.sol
@@ -456,7 +456,7 @@ abstract contract TbrUser is TbrBase {
       uint16 tokenOriginChain,
       bytes32 tokenOriginAddress,
       address recipient,
-      uint256 tokenAmount,
+      uint256 tbNormalizedTokenAmount,
       uint32 gasDropoff,
       bool unwrapIntent,
       uint retOffset
@@ -483,7 +483,7 @@ abstract contract TbrUser is TbrBase {
     }
 
     uint8 decimals = IERC20Metadata(token).decimals();
-    tokenAmount = deNormalizeAmount(tokenAmount, decimals);
+    uint256 tokenAmount = deNormalizeAmount(tbNormalizedTokenAmount, decimals);
 
     // If an unwrap is desired, unwrap and call recipient with full amount
     uint totalGasTokenAmount = gasDropoff;
@@ -584,7 +584,7 @@ library TokenBridgeVAAParser {
     uint16 tokenOriginChain,
     bytes32 tokenOriginAddress,
     address recipient,
-    uint256 tokenAmount,
+    uint256 tbNormalizedTokenAmount,
     uint32 gasDropoff,
     bool unwrapIntent,
     uint retOffset
@@ -605,7 +605,7 @@ library TokenBridgeVAAParser {
 
     // Note that the token amount is expressed in at most 8 decimals so
     // you need to denormalize this amount before calling transfer functions on the token.
-    (tokenAmount, dataOffset) = data.asUint256CdUnchecked(dataOffset);
+    (tbNormalizedTokenAmount, dataOffset) = data.asUint256CdUnchecked(dataOffset);
     (tokenOriginAddress, dataOffset) = data.asBytes32CdUnchecked(dataOffset);
     (tokenOriginChain, dataOffset) = data.asUint16CdUnchecked(dataOffset);
     dataOffset += _VAA_TOKEN_BRIDGE_RECIPIENT_SKIP;

--- a/evm/test/User.t.sol
+++ b/evm/test/User.t.sol
@@ -1290,6 +1290,7 @@ contract UserTest is TbrTestBase {
     );
 
     uint decimals = IERC20Metadata(address(gasToken)).decimals();
+    uint256 denormalizedAmount = deNormalizeAmount(amount, uint8(decimals));
     uint initialRecipienGasTokenBalance = recipient.balance;
     uint initialCallerBalance = address(this).balance;
 
@@ -1297,10 +1298,10 @@ contract UserTest is TbrTestBase {
     emit ITokenBridge.TransferRedeemed(peerChain, originTokenBridge, sequence);
 
     vm.expectEmit(address(gasToken));
-    emit IERC20.Transfer(address(tokenBridge), address(tbr), deNormalizeAmount(amount, uint8(decimals)));
+    emit IERC20.Transfer(address(tokenBridge), address(tbr), denormalizedAmount);
 
     vm.expectEmit(address(gasToken));
-    emit IWETH.Withdrawal(address(tbr), amount);
+    emit IWETH.Withdrawal(address(tbr), denormalizedAmount);
 
     invokeTbr(
       abi.encodePacked(
@@ -1313,7 +1314,7 @@ contract UserTest is TbrTestBase {
     );
 
     uint finalCallerBalance = address(this).balance;
-    assertEq(recipient.balance, initialRecipienGasTokenBalance + gasDropoff + amount);
+    assertEq(recipient.balance, initialRecipienGasTokenBalance + gasDropoff + denormalizedAmount);
     assertEq(finalCallerBalance, initialCallerBalance - gasDropoff);
   } 
 
@@ -1357,6 +1358,7 @@ contract UserTest is TbrTestBase {
 
     address tokenToTransfer = tokenBridge.wrappedAsset(tokenChain, tokenAddress);
     uint decimals = IERC20Metadata(tokenToTransfer).decimals();
+    uint256 denormalizedAmount = deNormalizeAmount(amount, uint8(decimals));
     uint initialRecipienGasTokenBalance = recipient.balance;
     uint initialRecipienTransferedTokenBalance = IERC20(tokenToTransfer).balanceOf(recipient);
     uint initialCallerBalance = address(this).balance;
@@ -1365,10 +1367,10 @@ contract UserTest is TbrTestBase {
     emit ITokenBridge.TransferRedeemed(peerChain, originTokenBridge, sequence);
 
     vm.expectEmit(tokenToTransfer);
-    emit IERC20.Transfer(address(0), address(tbr), deNormalizeAmount(amount, uint8(decimals)));
+    emit IERC20.Transfer(address(0), address(tbr), denormalizedAmount);
     
     vm.expectEmit(tokenToTransfer);
-    emit IERC20.Transfer(address(tbr), recipient, amount);
+    emit IERC20.Transfer(address(tbr), recipient, denormalizedAmount);
 
     invokeTbr(
       abi.encodePacked(
@@ -1384,7 +1386,7 @@ contract UserTest is TbrTestBase {
     uint finalCallerBalance = address(this).balance;
 
     assertEq(recipient.balance, initialRecipienGasTokenBalance + gasDropoff);
-    assertEq(finalRecipienTransferedTokenBalance, initialRecipienTransferedTokenBalance + amount);
+    assertEq(finalRecipienTransferedTokenBalance, initialRecipienTransferedTokenBalance + denormalizedAmount);
     assertEq(finalCallerBalance, initialCallerBalance - gasDropoff);
   }
 

--- a/sdk/evm/tbrv3/contract.ts
+++ b/sdk/evm/tbrv3/contract.ts
@@ -78,9 +78,11 @@ export interface RelayingFeeInput {
 
 export type TokenBridgeAllowances = Readonly<Record<string, bigint>>;
 
+export type FeeEstimation = RootQuery & { query: "RelayFee" } & RelayingFeeReturn;
+
 export interface RelayingFeeResult {
   allowances: TokenBridgeAllowances;
-  feeEstimations: RoArray<RootQuery & { query: "RelayFee" } & RelayingFeeReturn>;
+  feeEstimations: RoArray<FeeEstimation>;
 }
 
 export type TransferTokenWithRelayInput =
@@ -369,7 +371,7 @@ export class Tbrv3 {
 
     const queryResults = await this.query([...relayFeeQueries, ...allowanceQueries]);
 
-    const ret: any = {allowances: {}, feeEstimations: []};
+    const ret = {allowances: {} as Record<string, bigint>, feeEstimations: [] as FeeEstimation[]} satisfies RelayingFeeResult;
     for (const qRes of queryResults)
       if (qRes.query === "RelayFee") {
         const {result, ...args} = qRes;

--- a/sdk/evm/tbrv3/contract.ts
+++ b/sdk/evm/tbrv3/contract.ts
@@ -34,6 +34,7 @@ import {
   baseRelayingConfigReturnLayout,
   allowanceTokenBridgeReturnLayout,
   execParamsLayout,
+  peerAddressItem,
 } from "./layouts.js";
 import {
   AccessControlQuery,
@@ -236,7 +237,9 @@ export class Tbrv3 {
             deserializeResult(configQuery, baseFeeItem);
           else if (configQuery.query === "MaxGasDropoff")
             deserializeResult(configQuery, gasDropoffItem);
-          else //must be either "CanonicalPeer" or "FeeRecipient"
+          else if (configQuery.query === "CanonicalPeer")
+            deserializeResult(configQuery, peerAddressItem)
+          else //must be "FeeRecipient"
             deserializeResult(configQuery, evmAddressItem);
       else if (query.query === "AllowanceTokenBridge")
         deserializeResult(query, allowanceTokenBridgeReturnLayout);

--- a/sdk/evm/tbrv3/layouts.ts
+++ b/sdk/evm/tbrv3/layouts.ts
@@ -15,11 +15,16 @@ const peerChainItem = {
   name: "chain", ...layoutItems.chainItem({ allowedChains: supportedChains }) 
 } as const satisfies NamedLayoutItem;
 
+export const peerAddressItem = {
+  name: "address",
+  ...layoutItems.universalAddressItem,
+} as const;
+
 const peerChainAndAddressItem = {
   binary: "bytes",
   layout: [
     peerChainItem,
-    { name: "address", ...layoutItems.universalAddressItem }
+    peerAddressItem
   ]
 } as const;
 
@@ -164,14 +169,14 @@ const configCommandLayout =
     layouts: [
       [[ 0x00, "AddPeer"], [
         peerChainItem,
-        { name: "address", ...layoutItems.universalAddressItem }
+        peerAddressItem
       ]],
       [[ 0x01, "UpdateBaseFee"       ], [peerChainItem, { name: "value", ...baseFeeItem}]],
       [[ 0x02, "UpdateMaxGasDropoff" ], [peerChainItem, { name: "value", ...gasDropoffItem }]],
       [[ 0x03, "UpdateTransferPause" ], [peerChainItem, { name: "value", ...layoutItems.boolItem }]],
       [[ 0x0a, "UpdateFeeRecipient"  ], [{ name: "address",...evmAddressItem }]],
       // Only owner
-      [[ 0x0b, "UpdateCanonicalPeer" ], [peerChainItem, { name: "address", ...layoutItems.universalAddressItem }]],
+      [[ 0x0b, "UpdateCanonicalPeer" ], [peerChainItem, peerAddressItem]],
     ]
   } as const satisfies Layout;
 export type ConfigCommand = LayoutToType<typeof configCommandLayout>;
@@ -186,7 +191,7 @@ export const configQueryLayout = {
     [[0x82, "BaseFee"         ], [peerChainItem]],
     [[0x83, "MaxGasDropoff"   ], [peerChainItem]],
     [[0x84, "CanonicalPeer"   ], [peerChainItem]],
-    [[0x85, "IsPeer"          ], [peerChainItem, { name: "address", ...layoutItems.universalAddressItem }]],
+    [[0x85, "IsPeer"          ], [peerChainItem, peerAddressItem]],
     [[0x86, "FeeRecipient"    ], []],
   ],
 } as const satisfies Layout;


### PR DESCRIPTION
- Fixes complete transfer when the token has more than 8 decimals.
- Fixes `CanonicalPeer` query result deserialization.
- Eliminates `any` type in EVM sdk implementation to reduce chance of mistakes.