### PR TITLE
evm: type safe connect method in SDK

### DIFF
--- a/connect/platforms/evm/src/automatic.ts
+++ b/connect/platforms/evm/src/automatic.ts
@@ -65,10 +65,11 @@ export class AutomaticTokenBridgeV3EVM<N extends Network, C extends EvmChains>
     const address = tokenBridgeRelayerV3Contracts.get(network, chain);
     if (!address) throw new Error(`TokenBridgeRelayerV3 contract not defined for chain ${chain}`);
 
-    this.tbr = Tbrv3.connect(
+    this.tbr = Tbrv3.connectUnknown(
       wrapEthersProvider(provider),
       network,
       chain,
+      new EvmAddress(address)
     );
 
     this.networkId = nativeChainIds.networkChainToNativeChainId.get(

--- a/deployment/config/read-configuration.ts
+++ b/deployment/config/read-configuration.ts
@@ -44,12 +44,12 @@ const readChainConfig: SolanaScriptCb & EvmScriptCb = async function (
   if (chainToPlatform(operatingChain.name) === "Evm") {
     const provider = getProvider(operatingChain);
     const tbrv3ProxyAddress = new EvmAddress(getContractAddress("TbrV3Proxies", operatingChainId));
-    const tbr = Tbrv3.connect(
+    const tbr = Tbrv3.connectUnknown(
       wrapEthersProvider(provider),
       operatingChain.network,
       operatingChain.name,
-      undefined,
-      tbrv3ProxyAddress
+      tbrv3ProxyAddress,
+      undefined
     );
 
     const otherChains = loadTbrPeers(operatingChain).map(({chainId}) => chainId);

--- a/deployment/evm/configure-fee-and-dropoff.ts
+++ b/deployment/evm/configure-fee-and-dropoff.ts
@@ -15,7 +15,12 @@ import { wrapEthersProvider } from "../helpers/evm.js";
  */
 evm.runOnEvms("configure-fee-and-dropoff", async (chain, signer, log) => {
   const tbrv3ProxyAddress = new EvmAddress(getContractAddress("TbrV3Proxies", chainToChainId(chain.name)));
-  const tbrv3 = Tbrv3.connect(wrapEthersProvider(signer.provider!), chain.network, "Sepolia", tbrv3ProxyAddress);
+  const tbrv3 = Tbrv3.connectUnknown(
+    wrapEthersProvider(signer.provider!),
+    chain.network,
+    chain.name,
+    tbrv3ProxyAddress
+  );
   const peers = loadTbrPeers(chain);
 
   const queries = [];

--- a/deployment/evm/configure-fee-and-dropoff.ts
+++ b/deployment/evm/configure-fee-and-dropoff.ts
@@ -7,7 +7,7 @@ import {
 import { chainIdToChain, chainToChainId, encoding } from "@wormhole-foundation/sdk-base";
 import { SupportedChain, Tbrv3 } from "@xlabs-xyz/evm-arbitrary-token-transfers";
 import { EvmTbrV3Config } from "../config/config.types.js";
-import { EvmAddress } from "@wormhole-foundation/sdk-evm/dist/cjs";
+import { EvmAddress } from "@wormhole-foundation/sdk-evm";
 import { wrapEthersProvider } from "../helpers/evm.js";
 
 /**

--- a/deployment/evm/read-configured-fee-and-dropoff.ts
+++ b/deployment/evm/read-configured-fee-and-dropoff.ts
@@ -4,7 +4,7 @@ import {
   loadTbrPeers,
 } from "../helpers/index.js";
 import { chainIdToChain, chainToChainId } from "@wormhole-foundation/sdk-base";
-import { EvmAddress } from "@wormhole-foundation/sdk-evm/dist/cjs";
+import { EvmAddress } from "@wormhole-foundation/sdk-evm";
 import { SupportedChain, Tbrv3 } from "@xlabs-xyz/evm-arbitrary-token-transfers";
 import { wrapEthersProvider } from "../helpers/evm.js";
   

--- a/deployment/evm/read-configured-fee-and-dropoff.ts
+++ b/deployment/evm/read-configured-fee-and-dropoff.ts
@@ -15,7 +15,7 @@ evm.runOnEvmsSequentially("read-configured-fee-and-dropoff", async (operatingCha
   console.log(`Operating chain: ${operatingChain.name}`);
 
   const tbrv3ProxyAddress = new EvmAddress(getContractAddress("TbrV3Proxies", chainToChainId(operatingChain.name)));
-  const tbrv3 = Tbrv3.connect(
+  const tbrv3 = Tbrv3.connectUnknown(
     wrapEthersProvider(signer.provider!),
     operatingChain.network,
     operatingChain.name,

--- a/deployment/evm/register-peers.ts
+++ b/deployment/evm/register-peers.ts
@@ -16,11 +16,10 @@ import { wrapEthersProvider } from "../helpers/evm.js";
  */
 evm.runOnEvms("register-peers", async (operatingChain, signer, log) => {
   const tbrv3ProxyAddress = new EvmAddress(getContractAddress("TbrV3Proxies", chainToChainId(operatingChain.name)));
-  const tbrv3 = Tbrv3.connect(
+  const tbrv3 = Tbrv3.connectUnknown(
     wrapEthersProvider(signer.provider!),
     operatingChain.network,
     operatingChain.name,
-    undefined,
     tbrv3ProxyAddress
   );
   const peers = loadTbrPeers(operatingChain);

--- a/deployment/evm/set-canonical-peer.ts
+++ b/deployment/evm/set-canonical-peer.ts
@@ -15,22 +15,22 @@ import { wrapEthersProvider } from "../helpers/evm.js";
  *  - Add all other Tbrv3 contracts as peers
  * If no peer is registered for a chain, it will be set as the canonical peer.
  */
-evm.runOnEvms("set-canonical-peer", async (chain, signer, log) => {
+evm.runOnEvms("set-canonical-peer", async (operatingChain, signer, log) => {
   // HACK! resolveWrappedToken does not seem to work for CELO native currency.
-  const gasTokenAddress = chain.name === "Celo" ? new EvmAddress(getDependencyAddress("initGasToken", chain)) : undefined;
+  const gasTokenAddress = operatingChain.name === "Celo" ? new EvmAddress(getDependencyAddress("initGasToken", operatingChain)) : undefined;
 
-  const tbrv3ProxyAddress = new EvmAddress(getContractAddress("TbrV3Proxies", chainToChainId(chain.name)));
-  const tbrv3 = Tbrv3.connect(
+  const tbrv3ProxyAddress = new EvmAddress(getContractAddress("TbrV3Proxies", chainToChainId(operatingChain.name)));
+  const tbrv3 = Tbrv3.connectUnknown(
     wrapEthersProvider(signer.provider!),
-    chain.network,
-    chain.name,
-    gasTokenAddress,
-    tbrv3ProxyAddress
+    operatingChain.network,
+    operatingChain.name,
+    tbrv3ProxyAddress,
+    gasTokenAddress
   );
 
   // WARNING: We're going to assume we have only one peer per chain in this list
   // FIXME: create a loadCanonicalTbrPeers function and call that instead
-  const peers = loadTbrPeers(chain);
+  const peers = loadTbrPeers(operatingChain);
 
   const queries = [];
   for (const otherTbrv3 of peers) {
@@ -43,13 +43,12 @@ evm.runOnEvms("set-canonical-peer", async (chain, signer, log) => {
   }
 
   const commands = currentCanonicalPeers.filter(({result, chain}) =>
-      !result.equals(toUniversal(chain, getCanonicalPeerAddress(chain)))
-    )
-    .map(({chain}) => ({
-      command: "UpdateCanonicalPeer",
-      address: toUniversal(chain, getCanonicalPeerAddress(chain)),
-      chain,
-    } as const satisfies ConfigCommand));
+    !result.equals(toUniversal(chain, getCanonicalPeerAddress(chain)))
+  ).map(({chain}) => ({
+    command: "UpdateCanonicalPeer",
+    address: toUniversal(chain, getCanonicalPeerAddress(chain)),
+    chain,
+  } as const satisfies ConfigCommand));
 
   if (commands.length === 0) {
     log("All canonical peers are already correct.");
@@ -57,7 +56,7 @@ evm.runOnEvms("set-canonical-peer", async (chain, signer, log) => {
   }
 
   for (const command of commands) {
-    log(`Will update canonical peer: ${command.address} (${command.chain}) on chain ${chain.name}`);
+    log(`Will update canonical peer: ${command.address} (${command.chain}) on chain ${operatingChain.name}`);
   }
   const partialTx = tbrv3.execTx(0n, [{ command: "ConfigCommands", commands}]);
   const { txid } = await evm.sendTx(signer, { ...partialTx, data: encoding.hex.encode(partialTx.data, true) });

--- a/deployment/evm/unpause-transfer.ts
+++ b/deployment/evm/unpause-transfer.ts
@@ -15,11 +15,10 @@ import { wrapEthersProvider } from "../helpers/evm.js";
 evm.runOnEvms("unpause-transfer", async (operatingChain, signer, log) => {
   const tbrv3ProxyAddress = new EvmAddress(getContractAddress("TbrV3Proxies", chainToChainId(operatingChain.name)));
   const peers = loadTbrPeers(operatingChain);
-  const tbrv3 = Tbrv3.connect(
+  const tbrv3 = Tbrv3.connectUnknown(
     wrapEthersProvider(signer.provider!),
     operatingChain.network,
     operatingChain.name,
-    undefined,
     tbrv3ProxyAddress
   );
 

--- a/deployment/evm/verify.ts
+++ b/deployment/evm/verify.ts
@@ -6,7 +6,7 @@ import { EvmTbrV3Config } from "../config/config.types";
 import { Tbrv3 } from "@xlabs-xyz/evm-arbitrary-token-transfers";
 import { chainToChainId, encoding } from "@wormhole-foundation/sdk-base";
 import { ethers } from "ethers";
-import { EvmAddress } from "@wormhole-foundation/sdk-evm/dist/cjs";
+import { EvmAddress } from "@wormhole-foundation/sdk-evm";
 
 evm.runOnEvms("bytecode-verification-token-router", async (operatingChain, signer, log) => {
   // The root path of the foundry project

--- a/deployment/solana/unpause-contract.ts
+++ b/deployment/solana/unpause-contract.ts
@@ -6,15 +6,15 @@ import { dependencies } from '../helpers/env.js';
 import { PublicKey } from '@solana/web3.js';
 
 const unpauseContract: SolanaScriptCb = async function (
-  chain,
+  operatingChain,
   signer,
   // log,
 ) {
   const signerKey = new PublicKey(await signer.getAddress());
-  const connection = getConnection(chain);
-  const solanaDependencies = dependencies.find((d) => d.chainId === chainToChainId(chain.name));
+  const connection = getConnection(operatingChain);
+  const solanaDependencies = dependencies.find((d) => d.chainId === chainToChainId(operatingChain.name));
   if (solanaDependencies === undefined) {
-    throw new Error(`No dependencies found for chain ${chain.name}`);
+    throw new Error(`No dependencies found for chain ${operatingChain.name}`);
   }
   const tbr = await SolanaTokenBridgeRelayer.create(connection);
 

--- a/deployment/test/test-transfer.ts
+++ b/deployment/test/test-transfer.ts
@@ -165,11 +165,10 @@ async function sendEvmTestTransaction(
 
     const tbrv3ProxyAddress = new EvmAddress(getContractAddress('TbrV3Proxies', chainToChainId(chain.name)));
     const provider = getProvider(chain);
-    const tbrv3 = Tbrv3.connect(
+    const tbrv3 = Tbrv3.connectUnknown(
       wrapEthersProvider(provider!),
       chain.network,
       chain.name,
-      undefined,
       tbrv3ProxyAddress
     );
     const targetChains = availableChains.filter((c) => c.name === testTransfer.toChain);

--- a/sdk/evm/README.md
+++ b/sdk/evm/README.md
@@ -1,0 +1,8 @@
+## Usage
+
+### Instantiation
+
+`Tbrv3.connect` is mostly useful for logic that needs to interact with a few specific chains. It'll only typecheck for the few chains where there is a functioning deployment.
+This relies on a dictionary embedded in the library so if you find that a chain is not supported, try to upgrade the library.
+
+On the other hand, `Tbrv3.connectUnknown` is useful when you want a "type stable" interface that is easy to extend to new chains when you want to do an early integration ahead of a suitable SDK release.

--- a/sdk/evm/tbrv3/contract.ts
+++ b/sdk/evm/tbrv3/contract.ts
@@ -136,7 +136,6 @@ export const tbrV3Contracts = constMap(addresses);
 export const tbrV3Chains = tbrV3Contracts.subMap;
 
 type ChainsForNetwork<N extends NetworkMain> = Parameters<ReturnType<typeof tbrV3Chains<N>>>[number];
-// type Test2 = ChainsForNetwork<"Testnet">; //["Ethereum", "Avalanche", "Optimism", "Arbitrum", "Solana", "Base", "Polygon", "Sui"]
 
 export class Tbrv3 {
   /**

--- a/sdk/evm/tbrv3/contract.ts
+++ b/sdk/evm/tbrv3/contract.ts
@@ -50,8 +50,6 @@ import { getCanonicalToken } from "@wormhole-foundation/sdk-base/tokens";
 
 const WHOLE_EVM_GAS_TOKEN_UNITS = 10 ** 18;
 
-const zeroAddress = new EvmAddress(new Uint8Array(20));
-
 export interface PartialTx {
   /**
    * Amount of native token that should be attached to the transaction.

--- a/sdk/evm/tbrv3/contract.ts
+++ b/sdk/evm/tbrv3/contract.ts
@@ -1,11 +1,14 @@
 import {
   RoArray,
+  MapLevels,
   Chain,
   Network,
   serializeLayout,
   deserializeLayout,
   chainToPlatform,
   encoding,
+  constMap,
+  PlatformToChains,
 } from "@wormhole-foundation/sdk-base";
 import {
   keccak256,
@@ -113,12 +116,29 @@ export interface Transfer {
   args: TransferTokenWithRelayInput | TransferGasTokenWithRelayInput;
 };
 
-export class Tbrv3 {
-  static readonly addresses = {
-    Mainnet: zeroAddress,
-    Testnet: zeroAddress,
-  } as const satisfies Record<NetworkMain, EvmAddress>;
+// prettier-ignore
+export const addresses = [[
+  // TODO: update `Tbrv3.connect` parameter type when adding mainnet addresses.
+  "Mainnet", [
+  ]], [
+  "Testnet", [
+    ["Solana",          "ATtNvUvPZ3RU78P8Z5NuwHMTwQ8u8YsDWJ6YN6XvCErS"],
+    ["Avalanche",       "0x2BCC362643B0aa3b2608de68b2C2ef2e6eFd2bb6"],
+    ["Celo",            "0xAafD9ED1B11b1E1Bf08094Fa0E53e4eEa807B5D5"],
+    ["Sepolia",         "0xDc74c34F88d17895e31792439eaCE7cB1ed17d3a"],
+    ["ArbitrumSepolia", "0x7Ab71581b33948DdD07a4995a594d631BC4D2988"],
+    ["BaseSepolia",     "0xFe8dE1cf8893f0D928F007E787fD072660EAc06B"],
+    ["OptimismSepolia", "0x7057447A58b92e2C68A46548B6992203233e92eC"],
+  ]],
+] as const satisfies MapLevels<[Network, Chain, string]>;
 
+export const tbrV3Contracts = constMap(addresses);
+export const tbrV3Chains = tbrV3Contracts.subMap;
+
+type ChainsForNetwork<N extends NetworkMain> = Parameters<ReturnType<typeof tbrV3Chains<N>>>[number];
+// type Test2 = ChainsForNetwork<"Testnet">; //["Ethereum", "Avalanche", "Optimism", "Arbitrum", "Solana", "Base", "Polygon", "Sui"]
+
+export class Tbrv3 {
   /**
    * Creates the initialization configuration for the TBRv3 proxy contract.
    * 
@@ -141,17 +161,26 @@ export class Tbrv3 {
     return serializeLayout(proxyConstructorLayout, initConfig);
   }
 
-  static connect(
+  // TODO: update T constraint when adding mainnet addresses.
+  static connect<const T extends "Testnet">(
+    provider: ConnectionPrimitives,
+    network: T,
+    chain: ChainsForNetwork<T> & PlatformToChains<"Evm">,
+    gasToken?: EvmAddress,
+  ) {
+    // TODO: remove the need for these casts with an adequate helper from the SDK when there is one.
+    const address = tbrV3Contracts(network, chain as any) as string;
+    const evmAddress = new EvmAddress(address);
+    return this.connectUnknown(provider, network, chain, evmAddress, gasToken);
+  }
+
+  static connectUnknown(
     provider: ConnectionPrimitives,
     network: NetworkMain,
     chain: Chain,
+    address: EvmAddress,
     gasToken?: EvmAddress,
-    address?: EvmAddress,
   ) {
-    if (address === undefined && this.addresses[network].equals(zeroAddress)) {
-      throw new Error(`Tbrv3 address needs to be provided for network ${network}`);
-    }
-
     let defaultGasToken;
     try {
       ([,{address: defaultGasToken}] = resolveWrappedToken(network, chain, "native"));
@@ -170,7 +199,7 @@ export class Tbrv3 {
       throw new Error(`Unexpected gas token address ${gasToken} for network ${network} and chain ${chain}`);
     }
 
-    return new Tbrv3(provider, address ?? Tbrv3.addresses[network], gasToken);
+    return new Tbrv3(provider, address, gasToken);
   }
 
   constructor(

--- a/sdk/evm/tbrv3/contract.ts
+++ b/sdk/evm/tbrv3/contract.ts
@@ -134,6 +134,7 @@ export const tbrV3Contracts = constMap(addresses);
 export const tbrV3Chains = tbrV3Contracts.subMap;
 
 type ChainsForNetwork<N extends NetworkMain> = Parameters<ReturnType<typeof tbrV3Chains<N>>>[number];
+type EvmChainsForNetwork<N extends NetworkMain> = ChainsForNetwork<N> & PlatformToChains<"Evm">;
 
 export class Tbrv3 {
   /**
@@ -162,7 +163,7 @@ export class Tbrv3 {
   static connect<const T extends "Testnet">(
     provider: ConnectionPrimitives,
     network: T,
-    chain: ChainsForNetwork<T> & PlatformToChains<"Evm">,
+    chain: EvmChainsForNetwork<T>,
     gasToken?: EvmAddress,
   ) {
     // TODO: remove the need for these casts with an adequate helper from the SDK when there is one.


### PR DESCRIPTION
Splits factory logic for known peers and unknown peers.
`Tbrv3.connect` is mostly useful for logic that needs to interact with a few specific chains. It'll only typecheck for the few chains where there is a functioning deployment.
On the other hand, `Tbrv3.connectUnknown` is useful when you want a "type stable" interface that is easy to extend to new chains when you want to do an early integration ahead of a suitable SDK release.