### PR TITLE
Fix errors found in the TBRv3 Solana Audit

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -6,7 +6,6 @@ types = "sdk/solana/tbrv3/idl"
 
 [features]
 resolution = true
-skip-lint = true
 
 [programs.localnet]
 #token_bridge_relayer = "7TLiBkpDGshV4o3jmacTCx93CLkmo3VjZ111AsijN9f8"

--- a/sdk/solana/tbrv3/idl/token_bridge_relayer.ts
+++ b/sdk/solana/tbrv3/idl/token_bridge_relayer.ts
@@ -2006,61 +2006,66 @@ export type TokenBridgeRelayer = {
     },
     {
       "code": 6007,
+      "name": "dropoffExceedingMaximum",
+      "msg": "dropoffExceedingMaximum"
+    },
+    {
+      "code": 6008,
       "name": "feeExceedingMaximum",
       "msg": "feeExceedingMaximum"
     },
     {
-      "code": 6008,
+      "code": 6009,
       "name": "wrongFeeRecipient",
       "msg": "wrongFeeRecipient"
     },
     {
-      "code": 6009,
+      "code": 6010,
       "name": "wronglySetOptionalAccounts",
       "msg": "wronglySetOptionalAccounts"
     },
     {
-      "code": 6010,
+      "code": 6011,
       "name": "wrongMintAuthority",
       "msg": "wrongMintAuthority"
     },
     {
-      "code": 6011,
+      "code": 6012,
       "name": "invalidRecipient",
       "msg": "invalidRecipient"
     },
     {
-      "code": 6012,
+      "code": 6013,
       "name": "evmChainPriceNotSet",
       "msg": "evmChainPriceNotSet"
     },
     {
-      "code": 6013,
+      "code": 6014,
       "name": "chainPriceMismatch",
       "msg": "chainPriceMismatch"
     },
     {
-      "code": 6014,
+      "code": 6015,
       "name": "pausedTransfers",
       "msg": "pausedTransfers"
     },
     {
-      "code": 6015,
+      "code": 6016,
       "name": "invalidSendingPeer",
       "msg": "invalidSendingPeer"
     },
     {
-      "code": 6016,
+      "code": 6017,
       "name": "cannotRegisterSolana",
       "msg": "cannotRegisterSolana"
     },
     {
-      "code": 6017,
+      "code": 6018,
       "name": "invalidPeerAddress",
       "msg": "invalidPeerAddress"
     },
     {
-      "code": 6018,
+      "code": 6019,
       "name": "missingAssociatedTokenAccount",
       "msg": "missingAssociatedTokenAccount"
     }

--- a/sdk/solana/tbrv3/idl/token_bridge_relayer.ts
+++ b/sdk/solana/tbrv3/idl/token_bridge_relayer.ts
@@ -726,10 +726,7 @@ export type TokenBridgeRelayer = {
           "signer": true
         },
         {
-          "name": "owner",
-          "docs": [
-            "The designated owner of the program."
-          ]
+          "name": "owner"
         },
         {
           "name": "authBadge",
@@ -1432,9 +1429,6 @@ export type TokenBridgeRelayer = {
         },
         {
           "name": "feeRecipient",
-          "docs": [
-            "Fee recipient's account. The fee will be transferred to this account."
-          ],
           "writable": true,
           "relations": [
             "tbrConfig"

--- a/sdk/solana/tbrv3/idl/token_bridge_relayer.ts
+++ b/sdk/solana/tbrv3/idl/token_bridge_relayer.ts
@@ -103,7 +103,6 @@ export type TokenBridgeRelayer = {
       "accounts": [
         {
           "name": "owner",
-          "writable": true,
           "signer": true,
           "relations": [
             "tbrConfig"
@@ -1636,7 +1635,6 @@ export type TokenBridgeRelayer = {
           "docs": [
             "Owner of the program as set in the [`TbrConfig`] account."
           ],
-          "writable": true,
           "signer": true,
           "relations": [
             "tbrConfig"

--- a/sdk/solana/tbrv3/idl/token_bridge_relayer.ts
+++ b/sdk/solana/tbrv3/idl/token_bridge_relayer.ts
@@ -761,7 +761,7 @@ export type TokenBridgeRelayer = {
           "name": "tbrConfig",
           "docs": [
             "Owner Config account. This program requires that the `owner` specified",
-            "in the context equals the pubkey specified in this account. Mutable."
+            "in the context equals the pubkey specified in this account."
           ],
           "writable": true,
           "pda": {
@@ -2027,6 +2027,11 @@ export type TokenBridgeRelayer = {
       "code": 6019,
       "name": "missingAssociatedTokenAccount",
       "msg": "missingAssociatedTokenAccount"
+    },
+    {
+      "code": 6020,
+      "name": "overflow",
+      "msg": "overflow"
     }
   ],
   "types": [

--- a/sdk/solana/tbrv3/idl/token_bridge_relayer.ts
+++ b/sdk/solana/tbrv3/idl/token_bridge_relayer.ts
@@ -958,13 +958,6 @@ export type TokenBridgeRelayer = {
           ]
         },
         {
-          "name": "tbrConfig",
-          "docs": [
-            "Owner Config account. This program requires that the `signer` specified",
-            "in the context equals an authorized pubkey specified in this account."
-          ]
-        },
-        {
           "name": "peer",
           "writable": true,
           "pda": {
@@ -1186,14 +1179,6 @@ export type TokenBridgeRelayer = {
         {
           "name": "chainConfig",
           "writable": true
-        },
-        {
-          "name": "tbrConfig",
-          "docs": [
-            "Program Config account. This program requires that the [`signer`] specified",
-            "in the context equals a pubkey specified in this account. Mutable,",
-            "because we will update roles depending on the operation."
-          ]
         }
       ],
       "args": [
@@ -1635,17 +1620,7 @@ export type TokenBridgeRelayer = {
           "docs": [
             "Owner of the program as set in the [`TbrConfig`] account."
           ],
-          "signer": true,
-          "relations": [
-            "tbrConfig"
-          ]
-        },
-        {
-          "name": "tbrConfig",
-          "docs": [
-            "Owner Config account. This program requires that the `owner` specified",
-            "in the context equals the `owner` pubkey specified in this account."
-          ]
+          "signer": true
         },
         {
           "name": "peer"
@@ -1802,14 +1777,6 @@ export type TokenBridgeRelayer = {
         {
           "name": "chainConfig",
           "writable": true
-        },
-        {
-          "name": "tbrConfig",
-          "docs": [
-            "Program Config account. This program requires that the [`signer`] specified",
-            "in the context equals a pubkey specified in this account. Mutable,",
-            "because we will update roles depending on the operation."
-          ]
         }
       ],
       "args": [
@@ -1857,14 +1824,6 @@ export type TokenBridgeRelayer = {
         {
           "name": "chainConfig",
           "writable": true
-        },
-        {
-          "name": "tbrConfig",
-          "docs": [
-            "Program Config account. This program requires that the [`signer`] specified",
-            "in the context equals a pubkey specified in this account. Mutable,",
-            "because we will update roles depending on the operation."
-          ]
         }
       ],
       "args": [

--- a/sdk/solana/tbrv3/idl/token_bridge_relayer.ts
+++ b/sdk/solana/tbrv3/idl/token_bridge_relayer.ts
@@ -103,6 +103,7 @@ export type TokenBridgeRelayer = {
       "accounts": [
         {
           "name": "owner",
+          "writable": true,
           "signer": true,
           "relations": [
             "tbrConfig"
@@ -116,6 +117,116 @@ export type TokenBridgeRelayer = {
             "because we will update roles depending on the operation."
           ],
           "writable": true
+        },
+        {
+          "name": "upgradeLock",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  117,
+                  112,
+                  103,
+                  114,
+                  97,
+                  100,
+                  101,
+                  32,
+                  108,
+                  111,
+                  99,
+                  107
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "programData",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  13,
+                  74,
+                  247,
+                  118,
+                  36,
+                  164,
+                  201,
+                  97,
+                  25,
+                  221,
+                  241,
+                  144,
+                  142,
+                  148,
+                  63,
+                  218,
+                  160,
+                  137,
+                  78,
+                  28,
+                  18,
+                  140,
+                  195,
+                  112,
+                  127,
+                  26,
+                  150,
+                  227,
+                  211,
+                  125,
+                  216,
+                  108
+                ]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                2,
+                168,
+                246,
+                145,
+                78,
+                136,
+                161,
+                176,
+                226,
+                16,
+                21,
+                62,
+                247,
+                99,
+                174,
+                43,
+                0,
+                194,
+                185,
+                61,
+                22,
+                193,
+                36,
+                210,
+                192,
+                83,
+                122,
+                16,
+                4,
+                128,
+                0,
+                0
+              ]
+            }
+          }
+        },
+        {
+          "name": "bpfLoaderUpgradeable",
+          "address": "BPFLoaderUpgradeab1e11111111111111111111111"
         }
       ],
       "args": []
@@ -287,7 +398,10 @@ export type TokenBridgeRelayer = {
           "writable": true
         },
         {
-          "name": "peer"
+          "name": "peer",
+          "docs": [
+            "The TBR peer (_i.e._ `data().from_address()`). We do not care about the Token Bridge peer `vaa.meta.emitter_address`."
+          ]
         },
         {
           "name": "tokenBridgeConfig"
@@ -438,10 +552,6 @@ export type TokenBridgeRelayer = {
           }
         },
         {
-          "name": "previousOwner",
-          "signer": true
-        },
-        {
           "name": "authBadgePreviousOwner",
           "writable": true,
           "pda": {
@@ -476,6 +586,30 @@ export type TokenBridgeRelayer = {
             "because we will update roles depending on the operation."
           ],
           "writable": true
+        },
+        {
+          "name": "upgradeLock",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  117,
+                  112,
+                  103,
+                  114,
+                  97,
+                  100,
+                  101,
+                  32,
+                  108,
+                  111,
+                  99,
+                  107
+                ]
+              }
+            ]
+          }
         },
         {
           "name": "programData",
@@ -1073,7 +1207,12 @@ export type TokenBridgeRelayer = {
     {
       "name": "submitOwnerTransferRequest",
       "docs": [
-        "Updates the owner account. This needs to be either cancelled or approved."
+        "Updates the owner account. This needs to be either cancelled or approved.",
+        "",
+        "For safety reasons, transferring ownership is a 2-step process. This first step is to set the",
+        "new owner, and the second step is for the new owner to claim the ownership.",
+        "This is to prevent a situation where the ownership is transferred to an",
+        "address that is not able to claim the ownership (by mistake)."
       ],
       "discriminator": [
         99,
@@ -1116,6 +1255,116 @@ export type TokenBridgeRelayer = {
               }
             ]
           }
+        },
+        {
+          "name": "upgradeLock",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  117,
+                  112,
+                  103,
+                  114,
+                  97,
+                  100,
+                  101,
+                  32,
+                  108,
+                  111,
+                  99,
+                  107
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "programData",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  13,
+                  74,
+                  247,
+                  118,
+                  36,
+                  164,
+                  201,
+                  97,
+                  25,
+                  221,
+                  241,
+                  144,
+                  142,
+                  148,
+                  63,
+                  218,
+                  160,
+                  137,
+                  78,
+                  28,
+                  18,
+                  140,
+                  195,
+                  112,
+                  127,
+                  26,
+                  150,
+                  227,
+                  211,
+                  125,
+                  216,
+                  108
+                ]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                2,
+                168,
+                246,
+                145,
+                78,
+                136,
+                161,
+                176,
+                226,
+                16,
+                21,
+                62,
+                247,
+                99,
+                174,
+                43,
+                0,
+                194,
+                185,
+                61,
+                22,
+                193,
+                36,
+                210,
+                192,
+                83,
+                122,
+                16,
+                4,
+                128,
+                0,
+                0
+              ]
+            }
+          }
+        },
+        {
+          "name": "bpfLoaderUpgradeable",
+          "address": "BPFLoaderUpgradeab1e11111111111111111111111"
         }
       ],
       "args": [
@@ -2059,6 +2308,11 @@ export type TokenBridgeRelayer = {
       "name": "seedPrefixTemporary",
       "type": "bytes",
       "value": "[116, 109, 112]"
+    },
+    {
+      "name": "seedPrefixUpgradeLock",
+      "type": "bytes",
+      "value": "[117, 112, 103, 114, 97, 100, 101, 32, 108, 111, 99, 107]"
     }
   ]
 };

--- a/sdk/solana/tbrv3/token-bridge-relayer.ts
+++ b/sdk/solana/tbrv3/token-bridge-relayer.ts
@@ -483,16 +483,17 @@ export class SolanaTokenBridgeRelayer {
       throw new Error('Peers already exist. Use registerAdditionalPeer to add more peers.');
     }
 
-    const ixs = [];
+    const updateMaxGasDropoffIx =
+      config.maxGasDropoffMicroToken !== 0
+        ? [this.updateMaxGasDropoff(signer, chain, config.maxGasDropoffMicroToken)]
+        : [];
 
-    ixs.push(this.registerPeer(signer, chain, peerAddress));
-    if (config.maxGasDropoffMicroToken !== 0) {
-      ixs.push(this.updateMaxGasDropoff(signer, chain, config.maxGasDropoffMicroToken));
-    }
-    ixs.push(this.updateBaseFee(signer, chain, config.relayerFeeMicroUsd));
-    ixs.push(this.setPauseForOutboundTransfers(signer, chain, config.pausedOutboundTransfers));
-
-    return Promise.all(ixs);
+    return Promise.all([
+      this.registerPeer(signer, chain, peerAddress),
+      this.updateBaseFee(signer, chain, config.relayerFeeMicroUsd),
+      this.setPauseForOutboundTransfers(signer, chain, config.pausedOutboundTransfers),
+      ...updateMaxGasDropoffIx,
+    ]);
   }
 
   async registerAdditionalPeer(

--- a/sdk/solana/tbrv3/token-bridge-relayer.ts
+++ b/sdk/solana/tbrv3/token-bridge-relayer.ts
@@ -477,7 +477,6 @@ export class SolanaTokenBridgeRelayer {
       .accountsStrict({
         signer,
         authBadge: this.account.authBadge(signer).address,
-        tbrConfig: this.account.config().address,
         peer: this.account.peer(chain, peerAddress).address,
         chainConfig: this.account.chainConfig(chain).address,
         systemProgram: SystemProgram.programId,
@@ -498,7 +497,6 @@ export class SolanaTokenBridgeRelayer {
       .updateCanonicalPeer()
       .accountsStrict({
         owner: config.owner,
-        tbrConfig: this.account.config().address,
         peer: this.account.peer(chain, peerAddress).address,
         chainConfig: this.account.chainConfig(chain).address,
         systemProgram: SystemProgram.programId,
@@ -522,7 +520,6 @@ export class SolanaTokenBridgeRelayer {
         signer,
         authBadge: this.account.authBadge(signer).address,
         chainConfig: this.account.chainConfig(chain).address,
-        tbrConfig: this.account.config().address,
       })
       .instruction();
   }
@@ -541,15 +538,16 @@ export class SolanaTokenBridgeRelayer {
         signer,
         authBadge: this.account.authBadge(signer).address,
         chainConfig: this.account.chainConfig(chain).address,
-        tbrConfig: this.account.config().address,
       })
       .instruction();
   }
 
   /**
+   * Change the fee asked for relaying a transfer.
+   *
    * Signer: the Owner or an Admin.
    */
-  async updateRelayerFee(
+  async updateBaseFee(
     signer: PublicKey,
     chain: Chain,
     relayerFee: number,
@@ -560,7 +558,6 @@ export class SolanaTokenBridgeRelayer {
         signer,
         authBadge: this.account.authBadge(signer).address,
         chainConfig: this.account.chainConfig(chain).address,
-        tbrConfig: this.account.config().address,
       })
       .instruction();
   }

--- a/sdk/solana/tbrv3/token-bridge-relayer.ts
+++ b/sdk/solana/tbrv3/token-bridge-relayer.ts
@@ -410,7 +410,6 @@ export class SolanaTokenBridgeRelayer {
       .confirmOwnerTransferRequest()
       .accounts({
         newOwner: config.pendingOwner ?? throwError('No pending owner in the program'),
-        previousOwner: config.owner,
         tbrConfig: this.account.config().address,
       })
       .instruction();
@@ -420,12 +419,9 @@ export class SolanaTokenBridgeRelayer {
    * Signer: the Owner.
    */
   async cancelOwnerTransferRequest(): Promise<TransactionInstruction> {
-    const config = await this.read.config();
-
     return this.program.methods
       .cancelOwnerTransferRequest()
-      .accountsStrict({
-        owner: config.owner,
+      .accounts({
         tbrConfig: this.account.config().address,
       })
       .instruction();

--- a/sdk/solana/tbrv3/token-bridge-relayer.ts
+++ b/sdk/solana/tbrv3/token-bridge-relayer.ts
@@ -419,9 +419,12 @@ export class SolanaTokenBridgeRelayer {
    * Signer: the Owner.
    */
   async cancelOwnerTransferRequest(): Promise<TransactionInstruction> {
+    const config = await this.read.config();
+
     return this.program.methods
       .cancelOwnerTransferRequest()
-      .accounts({
+      .accountsPartial({
+        owner: config.owner,
         tbrConfig: this.account.config().address,
       })
       .instruction();

--- a/solana/programs/token-bridge-relayer/src/error.rs
+++ b/solana/programs/token-bridge-relayer/src/error.rs
@@ -90,4 +90,8 @@ pub(crate) enum TokenBridgeRelayerError {
     /// unwrap intent is set to `true`.
     #[msg("MissingAssociatedTokenAccount")]
     MissingAssociatedTokenAccount,
+
+    /// Numerical overflow.
+    #[msg("Overflow")]
+    Overflow,
 }

--- a/solana/programs/token-bridge-relayer/src/error.rs
+++ b/solana/programs/token-bridge-relayer/src/error.rs
@@ -33,6 +33,10 @@ pub(crate) enum TokenBridgeRelayerError {
     #[msg("AlreadyTheCanonicalPeer")]
     AlreadyTheCanonicalPeer,
 
+    /// The dropoff amount it higher than the one authorized for the target chain.
+    #[msg("DropoffExceedingMaximum")]
+    DropoffExceedingMaximum,
+
     /// Fee exceed what the user has set as a maximum.
     #[msg("FeeExceedingMaximum")]
     FeeExceedingMaximum,

--- a/solana/programs/token-bridge-relayer/src/lib.rs
+++ b/solana/programs/token-bridge-relayer/src/lib.rs
@@ -18,6 +18,9 @@ pub mod constant {
 
     #[constant]
     pub const SEED_PREFIX_TEMPORARY: &[u8] = b"tmp";
+
+    #[constant]
+    pub const SEED_PREFIX_UPGRADE_LOCK: &[u8] = b"upgrade lock";
 }
 
 #[program]
@@ -35,6 +38,11 @@ pub mod token_bridge_relayer {
     /* Roles */
 
     /// Updates the owner account. This needs to be either cancelled or approved.
+    ///
+    /// For safety reasons, transferring ownership is a 2-step process. This first step is to set the
+    /// new owner, and the second step is for the new owner to claim the ownership.
+    /// This is to prevent a situation where the ownership is transferred to an
+    /// address that is not able to claim the ownership (by mistake).
     pub fn submit_owner_transfer_request(
         ctx: Context<SubmitOwnerTransfer>,
         new_owner: Pubkey,

--- a/solana/programs/token-bridge-relayer/src/lib.rs
+++ b/solana/programs/token-bridge-relayer/src/lib.rs
@@ -20,7 +20,7 @@ pub mod constant {
     pub const SEED_PREFIX_TEMPORARY: &[u8] = b"tmp";
 
     #[constant]
-    pub const SEED_PREFIX_UPGRADE_LOCK: &[u8] = b"upgrade lock";
+    pub const SEED_PREFIX_UPGRADE_LOCK: &[u8] = b"upgrade_lock";
 }
 
 #[program]

--- a/solana/programs/token-bridge-relayer/src/processor/chain_config.rs
+++ b/solana/programs/token-bridge-relayer/src/processor/chain_config.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::TokenBridgeRelayerError,
-    state::{AuthBadgeState, ChainConfigState, TbrConfigState},
+    state::{AuthBadgeState, ChainConfigState},
 };
 use anchor_lang::prelude::*;
 
@@ -16,11 +16,6 @@ pub struct UpdateChainConfig<'info> {
 
     #[account(mut)]
     pub chain_config: Account<'info, ChainConfigState>,
-
-    /// Program Config account. This program requires that the [`signer`] specified
-    /// in the context equals a pubkey specified in this account. Mutable,
-    /// because we will update roles depending on the operation.
-    pub tbr_config: Account<'info, TbrConfigState>,
 }
 
 pub fn set_pause_for_outbound_transfers(

--- a/solana/programs/token-bridge-relayer/src/processor/inbound.rs
+++ b/solana/programs/token-bridge-relayer/src/processor/inbound.rs
@@ -44,7 +44,7 @@ pub struct CompleteTransfer<'info> {
     /// transaction. This instruction verifies that the recipient key
     /// passed in this context matches the intended recipient in the vaa.
     #[account(mut)]
-    pub recipient: AccountInfo<'info>,
+    pub recipient: UncheckedAccount<'info>,
 
     /// Verified Wormhole message account. Read-only.
     pub vaa: Account<'info, PostedRelayerMessage>,

--- a/solana/programs/token-bridge-relayer/src/processor/inbound.rs
+++ b/solana/programs/token-bridge-relayer/src/processor/inbound.rs
@@ -23,7 +23,7 @@ pub struct CompleteTransfer<'info> {
     pub tbr_config: Box<Account<'info, TbrConfigState>>,
 
     /// Mint info. This is the SPL token that will be bridged over to the
-    /// foreign contract. Mutable.
+    /// foreign contract.
     ///
     /// In the case of a native transfer, it's the mint for the token wrapped by Wormhole;
     /// in the case of a wrapped transfer, it's the native SPL token mint.
@@ -32,7 +32,7 @@ pub struct CompleteTransfer<'info> {
 
     /// Recipient associated token account. The recipient authority check
     /// is necessary to ensure that the recipient is the intended recipient
-    /// of the bridged tokens. Mutable.
+    /// of the bridged tokens.
     #[account(
         mut,
         associated_token::mint = mint,
@@ -89,7 +89,7 @@ pub struct CompleteTransfer<'info> {
     /// CHECK: Token Bridge custody. This is the Token Bridge program's token
     /// account that holds this mint's balance. This account needs to be
     /// unchecked because a token account may not have been created for this
-    /// mint yet. Mutable.
+    /// mint yet.
     ///
     /// # Exclusive
     ///
@@ -143,8 +143,6 @@ pub fn complete_transfer(
         unwrap_intent,
     } = *ctx.accounts.vaa.message().data();
     let gas_dropoff_amount = denormalize_dropoff_to_lamports(gas_dropoff_amount);
-
-    let _x = ctx.accounts.vaa.message();
 
     let redeemer_seeds = &[
         token_bridge::SEED_PREFIX_REDEEMER.as_ref(),

--- a/solana/programs/token-bridge-relayer/src/processor/inbound.rs
+++ b/solana/programs/token-bridge-relayer/src/processor/inbound.rs
@@ -61,10 +61,10 @@ pub struct CompleteTransfer<'info> {
     #[account(mut)]
     pub temporary_account: UncheckedAccount<'info>,
 
+    /// The TBR peer (_i.e._ `data().from_address()`). We do not care about the Token Bridge peer `vaa.meta.emitter_address`.
     #[account(
-        constraint = {
-            peer.address == *vaa.data().from_address()
-        } @ TokenBridgeRelayerError::InvalidSendingPeer
+        constraint = peer.address == *vaa.data().from_address() && peer.chain_id == vaa.meta.emitter_chain
+            @ TokenBridgeRelayerError::InvalidSendingPeer
     )]
     pub peer: Account<'info, PeerState>,
 
@@ -143,6 +143,8 @@ pub fn complete_transfer(
         unwrap_intent,
     } = *ctx.accounts.vaa.message().data();
     let gas_dropoff_amount = denormalize_dropoff_to_lamports(gas_dropoff_amount);
+
+    let _x = ctx.accounts.vaa.message();
 
     let redeemer_seeds = &[
         token_bridge::SEED_PREFIX_REDEEMER.as_ref(),

--- a/solana/programs/token-bridge-relayer/src/processor/initialize.rs
+++ b/solana/programs/token-bridge-relayer/src/processor/initialize.rs
@@ -16,8 +16,8 @@ pub struct Initialize<'info> {
     #[account(mut)]
     pub deployer: Signer<'info>,
 
-    /// The designated owner of the program.
-    pub owner: AccountInfo<'info>,
+    /// CHECK: The account to be used as the owner of the program.
+    pub owner: UncheckedAccount<'info>,
 
     #[account(
         init,
@@ -61,6 +61,7 @@ pub struct Initialize<'info> {
     )]
     pub wormhole_redeemer: UncheckedAccount<'info>,
 
+    /// CHECK: The BPF loader program.
     #[account(address = bpf_loader_upgradeable::ID)]
     pub bpf_loader_upgradeable: UncheckedAccount<'info>,
 

--- a/solana/programs/token-bridge-relayer/src/processor/initialize.rs
+++ b/solana/programs/token-bridge-relayer/src/processor/initialize.rs
@@ -17,7 +17,7 @@ pub struct Initialize<'info> {
     pub deployer: Signer<'info>,
 
     /// The designated owner of the program.
-    pub owner: UncheckedAccount<'info>,
+    pub owner: AccountInfo<'info>,
 
     #[account(
         init,
@@ -29,7 +29,7 @@ pub struct Initialize<'info> {
     pub auth_badge: Account<'info, AuthBadgeState>,
 
     /// Owner Config account. This program requires that the `owner` specified
-    /// in the context equals the pubkey specified in this account. Mutable.
+    /// in the context equals the pubkey specified in this account.
     #[account(
         init,
         payer = deployer,
@@ -47,12 +47,14 @@ pub struct Initialize<'info> {
     )]
     program_data: Account<'info, ProgramData>,
 
+    /// CHECK: An account used by the Token Bridge.
     #[account(
         seeds = [token_bridge::SEED_PREFIX_SENDER],
         bump
     )]
     pub wormhole_sender: UncheckedAccount<'info>,
 
+    /// CHECK: An account used by the Token Bridge.
     #[account(
         seeds = [token_bridge::SEED_PREFIX_REDEEMER],
         bump
@@ -115,11 +117,10 @@ pub fn initialize<'a, 'b, 'c, 'info>(
     );
 
     for (admin, badge_acc_info) in zip(admins, ctx.remaining_accounts) {
-        let bump = Pubkey::find_program_address(
+        let (_pubkey, bump) = Pubkey::find_program_address(
             &[AuthBadgeState::SEED_PREFIX, admin.to_bytes().as_ref()],
             ctx.program_id,
-        )
-        .1;
+        );
         let badge_seeds = [AuthBadgeState::SEED_PREFIX, &admin.to_bytes(), &[bump]];
 
         // Before calling `create_account`, we need to verify that the account

--- a/solana/programs/token-bridge-relayer/src/processor/outbound.rs
+++ b/solana/programs/token-bridge-relayer/src/processor/outbound.rs
@@ -116,7 +116,7 @@ pub struct OutboundTransfer<'info> {
     /// CHECK: Token Bridge emitter.
     pub token_bridge_emitter: UncheckedAccount<'info>,
 
-    /// CHECK: Token Bridge sequence.
+    /// CHECK: Token Bridge sequence. Mutable.
     #[account(mut)]
     pub token_bridge_sequence: UncheckedAccount<'info>,
 

--- a/solana/programs/token-bridge-relayer/src/processor/outbound.rs
+++ b/solana/programs/token-bridge-relayer/src/processor/outbound.rs
@@ -36,7 +36,7 @@ pub struct OutboundTransfer<'info> {
     pub chain_config: Box<Account<'info, ChainConfigState>>,
 
     /// Mint info. This is the SPL token that will be bridged over to the
-    /// canonical peer. Mutable.
+    /// canonical peer.
     ///
     /// In the case of a native transfer, it's the native mint; in the case of a
     /// wrapped transfer, it's the token wrapped by Wormhole.
@@ -80,7 +80,7 @@ pub struct OutboundTransfer<'info> {
     /// CHECK: Token Bridge custody. This is the Token Bridge program's token
     /// account that holds this mint's balance. This account needs to be
     /// unchecked because a token account may not have been created for this
-    /// mint yet. Mutable.
+    /// mint yet.
     ///
     /// # Exclusive
     ///

--- a/solana/programs/token-bridge-relayer/src/processor/outbound.rs
+++ b/solana/programs/token-bridge-relayer/src/processor/outbound.rs
@@ -62,7 +62,7 @@ pub struct OutboundTransfer<'info> {
     #[account(mut)]
     pub temporary_account: UncheckedAccount<'info>,
 
-    /// Fee recipient's account. The fee will be transferred to this account.
+    /// CHECK: Fee recipient's account. The fee will be transferred to this account.
     #[account(mut)]
     pub fee_recipient: UncheckedAccount<'info>,
 
@@ -131,8 +131,9 @@ pub struct OutboundTransfer<'info> {
         ],
         bump,
     )]
-    pub wormhole_message: AccountInfo<'info>,
+    pub wormhole_message: UncheckedAccount<'info>,
 
+    /// CHECK: Wormhole sender.
     pub wormhole_sender: UncheckedAccount<'info>,
 
     /// CHECK: Wormhole fee collector. Mutable.

--- a/solana/programs/token-bridge-relayer/src/processor/outbound.rs
+++ b/solana/programs/token-bridge-relayer/src/processor/outbound.rs
@@ -184,6 +184,11 @@ pub fn transfer_tokens(
         &[ctx.accounts.tbr_config.sender_bump],
     ];
 
+    require!(
+        dropoff_amount_micro <= ctx.accounts.chain_config.max_gas_dropoff_micro_token,
+        TokenBridgeRelayerError::DropoffExceedingMaximum
+    );
+
     let transferred_amount = normalize_token_amount(transferred_amount, &ctx.accounts.mint);
     let total_fees_lamports = calculate_total_fee(
         &ctx.accounts.tbr_config,

--- a/solana/programs/token-bridge-relayer/src/processor/owner.rs
+++ b/solana/programs/token-bridge-relayer/src/processor/owner.rs
@@ -40,6 +40,7 @@ pub struct SubmitOwnerTransfer<'info> {
     )]
     program_data: Account<'info, ProgramData>,
 
+    /// CHECK: The BPF loader program.
     #[account(address = bpf_loader_upgradeable::ID)]
     pub bpf_loader_upgradeable: UncheckedAccount<'info>,
 }
@@ -124,6 +125,7 @@ pub struct ConfirmOwnerTransfer<'info> {
     )]
     program_data: Account<'info, ProgramData>,
 
+    /// CHECK: The BPF loader program.
     #[account(address = bpf_loader_upgradeable::ID)]
     pub bpf_loader_upgradeable: UncheckedAccount<'info>,
 
@@ -186,6 +188,7 @@ pub struct CancelOwnerTransfer<'info> {
     )]
     program_data: Account<'info, ProgramData>,
 
+    /// CHECK: The BPF loader program.
     #[account(address = bpf_loader_upgradeable::ID)]
     pub bpf_loader_upgradeable: UncheckedAccount<'info>,
 }

--- a/solana/programs/token-bridge-relayer/src/processor/owner.rs
+++ b/solana/programs/token-bridge-relayer/src/processor/owner.rs
@@ -81,8 +81,9 @@ pub struct ConfirmOwnerTransfer<'info> {
     #[account(mut)]
     pub new_owner: Signer<'info>,
 
+    /// CHECK: init_if_needed: If the new owner has already a badge, _i.e._ is an admin, we can reuse it. 
     #[account(
-        init,
+        init_if_needed,
         payer = new_owner,
         space = 8 + AuthBadgeState::INIT_SPACE,
         seeds = [AuthBadgeState::SEED_PREFIX, new_owner.key.to_bytes().as_ref()],

--- a/solana/programs/token-bridge-relayer/src/processor/owner.rs
+++ b/solana/programs/token-bridge-relayer/src/processor/owner.rs
@@ -159,7 +159,6 @@ pub fn confirm_owner_transfer_request(ctx: Context<ConfirmOwnerTransfer>) -> Res
 
 #[derive(Accounts)]
 pub struct CancelOwnerTransfer<'info> {
-    #[account(mut)]
     pub owner: Signer<'info>,
 
     /// Program Config account. This program requires that the [`signer`] specified

--- a/solana/programs/token-bridge-relayer/src/processor/peers.rs
+++ b/solana/programs/token-bridge-relayer/src/processor/peers.rs
@@ -82,7 +82,6 @@ pub fn register_peer(
 #[derive(Accounts)]
 pub struct UpdateCanonicalPeer<'info> {
     /// Owner of the program as set in the [`TbrConfig`] account.
-    #[account(mut)]
     pub owner: Signer<'info>,
 
     /// Owner Config account. This program requires that the `owner` specified

--- a/solana/programs/token-bridge-relayer/src/processor/peers.rs
+++ b/solana/programs/token-bridge-relayer/src/processor/peers.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::TokenBridgeRelayerError,
-    state::{AuthBadgeState, ChainConfigState, PeerState, TbrConfigState},
+    state::{AuthBadgeState, ChainConfigState, PeerState},
 };
 use anchor_lang::prelude::*;
 
@@ -17,10 +17,6 @@ pub struct RegisterPeer<'info> {
     /// Proof that the signer is authorized.
     #[account(constraint = &auth_badge.address == signer.key @ TokenBridgeRelayerError::OwnerOrAdminOnly)]
     pub auth_badge: Account<'info, AuthBadgeState>,
-
-    /// Owner Config account. This program requires that the `signer` specified
-    /// in the context equals an authorized pubkey specified in this account.
-    pub tbr_config: Account<'info, TbrConfigState>,
 
     #[account(
         init,
@@ -83,11 +79,6 @@ pub fn register_peer(
 pub struct UpdateCanonicalPeer<'info> {
     /// Owner of the program as set in the [`TbrConfig`] account.
     pub owner: Signer<'info>,
-
-    /// Owner Config account. This program requires that the `owner` specified
-    /// in the context equals the `owner` pubkey specified in this account.
-    #[account(has_one = owner @ TokenBridgeRelayerError::OwnerOnly)]
-    pub tbr_config: Account<'info, TbrConfigState>,
 
     #[account(
         constraint = {

--- a/solana/programs/token-bridge-relayer/src/utils.rs
+++ b/solana/programs/token-bridge-relayer/src/utils.rs
@@ -57,19 +57,36 @@ pub fn calculate_total_fee(
     */
 
     // Mwei = gas * Mwei/gas + bytes * Mwei/byte + µToken * Mwei/µToken
-    let total_fees_mwei = config.evm_transaction_gas * u64::from(oracle_evm_prices.gas_price)
-        + config.evm_transaction_size * u64::from(oracle_evm_prices.price_per_byte)
-        + u64::from(dropoff_amount_micro) * MWEI_PER_MICRO_ETH;
+    let total_fees_mwei = (|| {
+        let evm_transaction_fee_mwei = config
+            .evm_transaction_gas
+            .checked_mul(u64::from(oracle_evm_prices.gas_price))?;
+        let evm_tx_size_fee_mwei = config
+            .evm_transaction_size
+            .checked_mul(u64::from(oracle_evm_prices.price_per_byte))?;
+        let dropoff_mwei = u64::from(dropoff_amount_micro).checked_mul(MWEI_PER_MICRO_ETH)?;
+
+        evm_transaction_fee_mwei
+            .checked_add(evm_tx_size_fee_mwei)?
+            .checked_add(dropoff_mwei)
+    })()
+    .ok_or(TokenBridgeRelayerError::Overflow)?;
 
     // μusd = Mwei * μusd/Token / Mwei/Token + μusd)
     let total_fees_micro_usd = u64::try_from(
         u128::from(total_fees_mwei) * u128::from(oracle_evm_prices.gas_token_price) / MWEI_PER_ETH,
     )
-    .expect("Overflow")
-        + u64::from(chain_config.relayer_fee_micro_usd);
+    .map_err(|_| TokenBridgeRelayerError::Overflow)?
+    .checked_add(u64::from(chain_config.relayer_fee_micro_usd))
+    .ok_or(TokenBridgeRelayerError::Overflow)?;
 
     // lamports/SOL * μusd / μusd/SOL
-    Ok((LAMPORTS_PER_SOL * total_fees_micro_usd) / oracle_config.sol_price)
+    let fee = total_fees_micro_usd
+        .checked_mul(LAMPORTS_PER_SOL)
+        .map(|sol| sol / oracle_config.sol_price)
+        .ok_or(TokenBridgeRelayerError::Overflow)?;
+
+    Ok(fee)
 }
 
 /// This is a basic security against a wrong manip, to be sure that the prices

--- a/solana/tests/token-bridge-relayer-tests.ts
+++ b/solana/tests/token-bridge-relayer-tests.ts
@@ -715,6 +715,26 @@ describe('Token Bridge Relayer Program', () => {
       expect(vaa.payload.payload.recipient).deep.equal(foreignAddress);
     });
 
+    it('Fails to transfer a token due to dropoff exceeding maximum', async () => {
+      const gasDropoffAmount = 11_000_000; // ETH11
+      const unwrapIntent = false;
+      const transferredAmount = 321654n;
+
+      const tokenAccount = await barMint.mint(1_000_000_000n, unauthorizedClient.signer); //
+
+      const foreignAddress = $.universalAddress.generate();
+
+      const transferPromise = unauthorizedClient.transferTokens({
+        recipient: { address: foreignAddress, chain: ETHEREUM },
+        userTokenAccount: tokenAccount.publicKey,
+        transferredAmount,
+        gasDropoffAmount,
+        maxFeeLamports: 100_000_000n, // 0.1SOL max
+        unwrapIntent,
+      });
+      await assert.promise(transferPromise).failsWith('DropoffExceedingMaximum');
+    });
+
     after(async () => {
       await clientForeignToken.close();
     });

--- a/solana/tests/token-bridge-relayer-tests.ts
+++ b/solana/tests/token-bridge-relayer-tests.ts
@@ -144,6 +144,9 @@ describe('Token Bridge Relayer Program', () => {
       DEBUG,
     );
 
+    // Let's credit a badge, to verify that we cannot trigger a denial of service:
+    await $.airdrop(upgradeAuthorityClient.account.authBadge(adminClient1.publicKey).address);
+
     await upgradeAuthorityClient.initialize({
       feeRecipient,
       owner: ownerClient.publicKey,
@@ -457,6 +460,9 @@ describe('Token Bridge Relayer Program', () => {
 
       const foreignAddress = $.universalAddress.generate();
       const canonicalEthereum = await unauthorizedClient.read.canonicalPeer(ETHEREUM);
+
+      // Let's credit the temporary token account, to verify that we cannot trigger a denial of service:
+      await $.airdrop(unauthorizedClient.account.temporary(spl.NATIVE_MINT).address);
 
       await unauthorizedClient.transferTokens({
         recipient: { address: foreignAddress, chain: ETHEREUM },

--- a/solana/tests/token-bridge-relayer-tests.ts
+++ b/solana/tests/token-bridge-relayer-tests.ts
@@ -756,6 +756,7 @@ describe('Token Bridge Relayer Program', () => {
         gasDropoffAmount,
         maxFeeLamports: sol(0.1),
         unwrapIntent,
+        mintAddress: barMint.address,
       });
       await assert.promise(transferPromise).failsWith('DropoffExceedingMaximum');
     });

--- a/solana/tests/token-bridge-relayer-tests.ts
+++ b/solana/tests/token-bridge-relayer-tests.ts
@@ -532,7 +532,7 @@ describe('Token Bridge Relayer Program', () => {
     });
 
     it('Gets wrapped SOL back from another chain', async () => {
-      const [payer, recipient] = await $.airdrop([Keypair.generate(), $.keypair.generate()]);
+      const [payer, recipient] = await $.airdrop($.keypair.several(2));
       // Associated token account already existing (to test if it breaks the transfer completion):
       const recipientTokenAccount = await spl.createAssociatedTokenAccount(
         $.connection,

--- a/solana/tests/token-bridge-relayer-tests.ts
+++ b/solana/tests/token-bridge-relayer-tests.ts
@@ -520,7 +520,6 @@ describe('Token Bridge Relayer Program', () => {
       expect(vaa.payload.token.amount).equal(transferredAmount / 10n);
 
       expect(vaa.payload.payload.recipient).deep.equal(foreignAddress);
-      // We need to divide by 1 million because it's deserialized as the token, not µToken:
       expect(vaa.payload.payload.gasDropoff).equal(gasDropoffAmount);
       expect(vaa.payload.payload.unwrapIntent).equal(unwrapIntent);
     });
@@ -561,8 +560,7 @@ describe('Token Bridge Relayer Program', () => {
       expect(vaa.payload.token.amount).equal(transferredAmount / 100n);
 
       expect(vaa.payload.payload.recipient).deep.equal(foreignAddress);
-      // We need to divide by 1 million because it's deserialize as the token, not µToken:
-      expect(vaa.payload.payload.gasDropoff).equal(gasDropoffAmount / 1_000_000);
+      expect(vaa.payload.payload.gasDropoff).equal(gasDropoffAmount);
       expect(vaa.payload.payload.unwrapIntent).equal(unwrapIntent);
     });
 
@@ -741,7 +739,7 @@ describe('Token Bridge Relayer Program', () => {
     });
 
     it('Fails to transfer a token due to dropoff exceeding maximum', async () => {
-      const gasDropoffAmount = eth(11);
+      const gasDropoffAmount = 11;
       const unwrapIntent = false;
       const transferredAmount = 321654n;
 

--- a/solana/tests/token-bridge-relayer-tests.ts
+++ b/solana/tests/token-bridge-relayer-tests.ts
@@ -78,7 +78,11 @@ describe('Token Bridge Relayer Program', () => {
   const ethereumTbrPeer1 = $.universalAddress.generate('ethereum');
   const ethereumTbrPeer2 = $.universalAddress.generate('ethereum');
   const oasisTbrPeer = $.universalAddress.generate('ethereum');
-  const bpfProgram = new BpfLoaderUpgradeableProgram(ownerClient.client.program.programId, $.connection);
+
+  const bpfProgram = new BpfLoaderUpgradeableProgram(
+    ownerClient.client.program.programId,
+    $.connection,
+  );
 
   before(async () => {
     await $.airdrop([
@@ -187,12 +191,12 @@ describe('Token Bridge Relayer Program', () => {
 
     it('Rejects a transfer validation by an unauthorized account', async () => {
       await assert
-        .promise(unauthorizedClient.confirmOwnerTransferRequest(ownerClient.signer))
+        .promise(unauthorizedClient.confirmOwnerTransferRequest())
         .failsWith('Signature verification failed');
     });
 
     it('Accepts a transfer validation by the rightful new owner', async () => {
-      await newOwnerClient.confirmOwnerTransferRequest(ownerClient.signer);
+      await newOwnerClient.confirmOwnerTransferRequest();
 
       // Verify that the authority has been updated to the new owner.
       const { upgradeAuthority } = await bpfProgram.getdata();
@@ -218,7 +222,7 @@ describe('Token Bridge Relayer Program', () => {
 
       // Now the original owner cannot accept the ownership:
       await assert
-        .promise(ownerClient.confirmOwnerTransferRequest(ownerClient.signer))
+        .promise(ownerClient.confirmOwnerTransferRequest())
         .failsWith('No pending owner in the program');
     });
 

--- a/solana/tests/token-bridge-relayer-tests.ts
+++ b/solana/tests/token-bridge-relayer-tests.ts
@@ -720,7 +720,7 @@ describe('Token Bridge Relayer Program', () => {
       const unwrapIntent = false;
       const transferredAmount = 321654n;
 
-      const tokenAccount = await barMint.mint(1_000_000_000n, unauthorizedClient.signer); //
+      const tokenAccount = await barMint.mint(1_000_000_000n, unauthorizedClient.signer);
 
       const foreignAddress = $.universalAddress.generate();
 

--- a/solana/tests/utils/tbr-wrapper.ts
+++ b/solana/tests/utils/tbr-wrapper.ts
@@ -92,9 +92,9 @@ export class TbrWrapper {
     );
   }
 
-  async confirmOwnerTransferRequest(owner: Signer): Promise<VersionedTransactionResponse | null> {
+  async confirmOwnerTransferRequest(): Promise<VersionedTransactionResponse | null> {
     return $.getTransaction(
-      $.sendAndConfirm(await this.client.confirmOwnerTransferRequest(), this.signer, owner),
+      $.sendAndConfirm(await this.client.confirmOwnerTransferRequest(), this.signer),
     );
   }
 

--- a/solana/tests/utils/tbr-wrapper.ts
+++ b/solana/tests/utils/tbr-wrapper.ts
@@ -114,13 +114,30 @@ export class TbrWrapper {
     );
   }
 
-  async registerPeer(
+  async registerFirstPeer(
+    chain: Chain,
+    peerAddress: UniversalAddress,
+    config: {
+      maxGasDropoffMicroToken: number;
+      relayerFeeMicroUsd: number;
+      pausedOutboundTransfers: boolean;
+    },
+  ): Promise<VersionedTransactionResponse | null> {
+    return $.getTransaction(
+      $.sendAndConfirm(
+        await this.client.registerFirstPeer(this.publicKey, chain, peerAddress, config),
+        this.signer,
+      ),
+    );
+  }
+
+  async registerAdditionalPeer(
     chain: Chain,
     peerAddress: UniversalAddress,
   ): Promise<VersionedTransactionResponse | null> {
     return $.getTransaction(
       $.sendAndConfirm(
-        await this.client.registerPeer(this.publicKey, chain, peerAddress),
+        await this.client.registerAdditionalPeer(this.publicKey, chain, peerAddress),
         this.signer,
       ),
     );

--- a/solana/tests/utils/tbr-wrapper.ts
+++ b/solana/tests/utils/tbr-wrapper.ts
@@ -165,7 +165,7 @@ export class TbrWrapper {
   ): Promise<VersionedTransactionResponse | null> {
     return $.getTransaction(
       $.sendAndConfirm(
-        await this.client.updateRelayerFee(this.publicKey, chain, relayerFee),
+        await this.client.updateBaseFee(this.publicKey, chain, relayerFee),
         this.signer,
       ),
     );

--- a/target/idl/token_bridge_relayer.json
+++ b/target/idl/token_bridge_relayer.json
@@ -755,7 +755,7 @@
           "name": "tbr_config",
           "docs": [
             "Owner Config account. This program requires that the `owner` specified",
-            "in the context equals the pubkey specified in this account. Mutable."
+            "in the context equals the pubkey specified in this account."
           ],
           "writable": true,
           "pda": {
@@ -2021,6 +2021,11 @@
       "code": 6019,
       "name": "MissingAssociatedTokenAccount",
       "msg": "MissingAssociatedTokenAccount"
+    },
+    {
+      "code": 6020,
+      "name": "Overflow",
+      "msg": "Overflow"
     }
   ],
   "types": [

--- a/target/idl/token_bridge_relayer.json
+++ b/target/idl/token_bridge_relayer.json
@@ -1,5 +1,5 @@
 {
-  "address": "HrZSAEW9QVbC4kQu51C7oFMHaam18AvAhpbBYeY9mKht",
+  "address": "ttbrcA1ckR3D3Ff4VR1MJNCvA7t4d4XV9TcvrVp4AoM",
   "metadata": {
     "name": "token_bridge_relayer",
     "version": "3.0.0",
@@ -952,13 +952,6 @@
           ]
         },
         {
-          "name": "tbr_config",
-          "docs": [
-            "Owner Config account. This program requires that the `signer` specified",
-            "in the context equals an authorized pubkey specified in this account."
-          ]
-        },
-        {
           "name": "peer",
           "writable": true,
           "pda": {
@@ -1180,14 +1173,6 @@
         {
           "name": "chain_config",
           "writable": true
-        },
-        {
-          "name": "tbr_config",
-          "docs": [
-            "Program Config account. This program requires that the [`signer`] specified",
-            "in the context equals a pubkey specified in this account. Mutable,",
-            "because we will update roles depending on the operation."
-          ]
         }
       ],
       "args": [
@@ -1629,17 +1614,7 @@
           "docs": [
             "Owner of the program as set in the [`TbrConfig`] account."
           ],
-          "signer": true,
-          "relations": [
-            "tbr_config"
-          ]
-        },
-        {
-          "name": "tbr_config",
-          "docs": [
-            "Owner Config account. This program requires that the `owner` specified",
-            "in the context equals the `owner` pubkey specified in this account."
-          ]
+          "signer": true
         },
         {
           "name": "peer"
@@ -1796,14 +1771,6 @@
         {
           "name": "chain_config",
           "writable": true
-        },
-        {
-          "name": "tbr_config",
-          "docs": [
-            "Program Config account. This program requires that the [`signer`] specified",
-            "in the context equals a pubkey specified in this account. Mutable,",
-            "because we will update roles depending on the operation."
-          ]
         }
       ],
       "args": [
@@ -1851,14 +1818,6 @@
         {
           "name": "chain_config",
           "writable": true
-        },
-        {
-          "name": "tbr_config",
-          "docs": [
-            "Program Config account. This program requires that the [`signer`] specified",
-            "in the context equals a pubkey specified in this account. Mutable,",
-            "because we will update roles depending on the operation."
-          ]
         }
       ],
       "args": [

--- a/target/idl/token_bridge_relayer.json
+++ b/target/idl/token_bridge_relayer.json
@@ -97,7 +97,6 @@
       "accounts": [
         {
           "name": "owner",
-          "writable": true,
           "signer": true,
           "relations": [
             "tbr_config"
@@ -1630,7 +1629,6 @@
           "docs": [
             "Owner of the program as set in the [`TbrConfig`] account."
           ],
-          "writable": true,
           "signer": true,
           "relations": [
             "tbr_config"

--- a/target/idl/token_bridge_relayer.json
+++ b/target/idl/token_bridge_relayer.json
@@ -97,6 +97,7 @@
       "accounts": [
         {
           "name": "owner",
+          "writable": true,
           "signer": true,
           "relations": [
             "tbr_config"
@@ -110,6 +111,116 @@
             "because we will update roles depending on the operation."
           ],
           "writable": true
+        },
+        {
+          "name": "upgrade_lock",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  117,
+                  112,
+                  103,
+                  114,
+                  97,
+                  100,
+                  101,
+                  32,
+                  108,
+                  111,
+                  99,
+                  107
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program_data",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  13,
+                  74,
+                  247,
+                  118,
+                  36,
+                  164,
+                  201,
+                  97,
+                  25,
+                  221,
+                  241,
+                  144,
+                  142,
+                  148,
+                  63,
+                  218,
+                  160,
+                  137,
+                  78,
+                  28,
+                  18,
+                  140,
+                  195,
+                  112,
+                  127,
+                  26,
+                  150,
+                  227,
+                  211,
+                  125,
+                  216,
+                  108
+                ]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                2,
+                168,
+                246,
+                145,
+                78,
+                136,
+                161,
+                176,
+                226,
+                16,
+                21,
+                62,
+                247,
+                99,
+                174,
+                43,
+                0,
+                194,
+                185,
+                61,
+                22,
+                193,
+                36,
+                210,
+                192,
+                83,
+                122,
+                16,
+                4,
+                128,
+                0,
+                0
+              ]
+            }
+          }
+        },
+        {
+          "name": "bpf_loader_upgradeable",
+          "address": "BPFLoaderUpgradeab1e11111111111111111111111"
         }
       ],
       "args": []
@@ -281,7 +392,10 @@
           "writable": true
         },
         {
-          "name": "peer"
+          "name": "peer",
+          "docs": [
+            "The TBR peer (_i.e._ `data().from_address()`). We do not care about the Token Bridge peer `vaa.meta.emitter_address`."
+          ]
         },
         {
           "name": "token_bridge_config"
@@ -432,10 +546,6 @@
           }
         },
         {
-          "name": "previous_owner",
-          "signer": true
-        },
-        {
           "name": "auth_badge_previous_owner",
           "writable": true,
           "pda": {
@@ -470,6 +580,30 @@
             "because we will update roles depending on the operation."
           ],
           "writable": true
+        },
+        {
+          "name": "upgrade_lock",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  117,
+                  112,
+                  103,
+                  114,
+                  97,
+                  100,
+                  101,
+                  32,
+                  108,
+                  111,
+                  99,
+                  107
+                ]
+              }
+            ]
+          }
         },
         {
           "name": "program_data",
@@ -1067,7 +1201,12 @@
     {
       "name": "submit_owner_transfer_request",
       "docs": [
-        "Updates the owner account. This needs to be either cancelled or approved."
+        "Updates the owner account. This needs to be either cancelled or approved.",
+        "",
+        "For safety reasons, transferring ownership is a 2-step process. This first step is to set the",
+        "new owner, and the second step is for the new owner to claim the ownership.",
+        "This is to prevent a situation where the ownership is transferred to an",
+        "address that is not able to claim the ownership (by mistake)."
       ],
       "discriminator": [
         99,
@@ -1110,6 +1249,116 @@
               }
             ]
           }
+        },
+        {
+          "name": "upgrade_lock",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  117,
+                  112,
+                  103,
+                  114,
+                  97,
+                  100,
+                  101,
+                  32,
+                  108,
+                  111,
+                  99,
+                  107
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program_data",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  13,
+                  74,
+                  247,
+                  118,
+                  36,
+                  164,
+                  201,
+                  97,
+                  25,
+                  221,
+                  241,
+                  144,
+                  142,
+                  148,
+                  63,
+                  218,
+                  160,
+                  137,
+                  78,
+                  28,
+                  18,
+                  140,
+                  195,
+                  112,
+                  127,
+                  26,
+                  150,
+                  227,
+                  211,
+                  125,
+                  216,
+                  108
+                ]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                2,
+                168,
+                246,
+                145,
+                78,
+                136,
+                161,
+                176,
+                226,
+                16,
+                21,
+                62,
+                247,
+                99,
+                174,
+                43,
+                0,
+                194,
+                185,
+                61,
+                22,
+                193,
+                36,
+                210,
+                192,
+                83,
+                122,
+                16,
+                4,
+                128,
+                0,
+                0
+              ]
+            }
+          }
+        },
+        {
+          "name": "bpf_loader_upgradeable",
+          "address": "BPFLoaderUpgradeab1e11111111111111111111111"
         }
       ],
       "args": [
@@ -2053,6 +2302,11 @@
       "name": "SEED_PREFIX_TEMPORARY",
       "type": "bytes",
       "value": "[116, 109, 112]"
+    },
+    {
+      "name": "SEED_PREFIX_UPGRADE_LOCK",
+      "type": "bytes",
+      "value": "[117, 112, 103, 114, 97, 100, 101, 32, 108, 111, 99, 107]"
     }
   ]
 }

--- a/target/idl/token_bridge_relayer.json
+++ b/target/idl/token_bridge_relayer.json
@@ -720,10 +720,7 @@
           "signer": true
         },
         {
-          "name": "owner",
-          "docs": [
-            "The designated owner of the program."
-          ]
+          "name": "owner"
         },
         {
           "name": "auth_badge",
@@ -1426,9 +1423,6 @@
         },
         {
           "name": "fee_recipient",
-          "docs": [
-            "Fee recipient's account. The fee will be transferred to this account."
-          ],
           "writable": true,
           "relations": [
             "tbr_config"

--- a/target/idl/token_bridge_relayer.json
+++ b/target/idl/token_bridge_relayer.json
@@ -2000,61 +2000,66 @@
     },
     {
       "code": 6007,
+      "name": "DropoffExceedingMaximum",
+      "msg": "DropoffExceedingMaximum"
+    },
+    {
+      "code": 6008,
       "name": "FeeExceedingMaximum",
       "msg": "FeeExceedingMaximum"
     },
     {
-      "code": 6008,
+      "code": 6009,
       "name": "WrongFeeRecipient",
       "msg": "WrongFeeRecipient"
     },
     {
-      "code": 6009,
+      "code": 6010,
       "name": "WronglySetOptionalAccounts",
       "msg": "WronglySetOptionalAccounts"
     },
     {
-      "code": 6010,
+      "code": 6011,
       "name": "WrongMintAuthority",
       "msg": "WrongMintAuthority"
     },
     {
-      "code": 6011,
+      "code": 6012,
       "name": "InvalidRecipient",
       "msg": "InvalidRecipient"
     },
     {
-      "code": 6012,
+      "code": 6013,
       "name": "EvmChainPriceNotSet",
       "msg": "EvmChainPriceNotSet"
     },
     {
-      "code": 6013,
+      "code": 6014,
       "name": "ChainPriceMismatch",
       "msg": "ChainPriceMismatch"
     },
     {
-      "code": 6014,
+      "code": 6015,
       "name": "PausedTransfers",
       "msg": "PausedTransfers"
     },
     {
-      "code": 6015,
+      "code": 6016,
       "name": "InvalidSendingPeer",
       "msg": "InvalidSendingPeer"
     },
     {
-      "code": 6016,
+      "code": 6017,
       "name": "CannotRegisterSolana",
       "msg": "CannotRegisterSolana"
     },
     {
-      "code": 6017,
+      "code": 6018,
       "name": "InvalidPeerAddress",
       "msg": "InvalidPeerAddress"
     },
     {
-      "code": 6018,
+      "code": 6019,
       "name": "MissingAssociatedTokenAccount",
       "msg": "MissingAssociatedTokenAccount"
     }

--- a/target/types/token_bridge_relayer.ts
+++ b/target/types/token_bridge_relayer.ts
@@ -2006,61 +2006,66 @@ export type TokenBridgeRelayer = {
     },
     {
       "code": 6007,
+      "name": "dropoffExceedingMaximum",
+      "msg": "dropoffExceedingMaximum"
+    },
+    {
+      "code": 6008,
       "name": "feeExceedingMaximum",
       "msg": "feeExceedingMaximum"
     },
     {
-      "code": 6008,
+      "code": 6009,
       "name": "wrongFeeRecipient",
       "msg": "wrongFeeRecipient"
     },
     {
-      "code": 6009,
+      "code": 6010,
       "name": "wronglySetOptionalAccounts",
       "msg": "wronglySetOptionalAccounts"
     },
     {
-      "code": 6010,
+      "code": 6011,
       "name": "wrongMintAuthority",
       "msg": "wrongMintAuthority"
     },
     {
-      "code": 6011,
+      "code": 6012,
       "name": "invalidRecipient",
       "msg": "invalidRecipient"
     },
     {
-      "code": 6012,
+      "code": 6013,
       "name": "evmChainPriceNotSet",
       "msg": "evmChainPriceNotSet"
     },
     {
-      "code": 6013,
+      "code": 6014,
       "name": "chainPriceMismatch",
       "msg": "chainPriceMismatch"
     },
     {
-      "code": 6014,
+      "code": 6015,
       "name": "pausedTransfers",
       "msg": "pausedTransfers"
     },
     {
-      "code": 6015,
+      "code": 6016,
       "name": "invalidSendingPeer",
       "msg": "invalidSendingPeer"
     },
     {
-      "code": 6016,
+      "code": 6017,
       "name": "cannotRegisterSolana",
       "msg": "cannotRegisterSolana"
     },
     {
-      "code": 6017,
+      "code": 6018,
       "name": "invalidPeerAddress",
       "msg": "invalidPeerAddress"
     },
     {
-      "code": 6018,
+      "code": 6019,
       "name": "missingAssociatedTokenAccount",
       "msg": "missingAssociatedTokenAccount"
     }

--- a/target/types/token_bridge_relayer.ts
+++ b/target/types/token_bridge_relayer.ts
@@ -726,10 +726,7 @@ export type TokenBridgeRelayer = {
           "signer": true
         },
         {
-          "name": "owner",
-          "docs": [
-            "The designated owner of the program."
-          ]
+          "name": "owner"
         },
         {
           "name": "authBadge",
@@ -1432,9 +1429,6 @@ export type TokenBridgeRelayer = {
         },
         {
           "name": "feeRecipient",
-          "docs": [
-            "Fee recipient's account. The fee will be transferred to this account."
-          ],
           "writable": true,
           "relations": [
             "tbrConfig"

--- a/target/types/token_bridge_relayer.ts
+++ b/target/types/token_bridge_relayer.ts
@@ -103,7 +103,6 @@ export type TokenBridgeRelayer = {
       "accounts": [
         {
           "name": "owner",
-          "writable": true,
           "signer": true,
           "relations": [
             "tbrConfig"
@@ -1636,7 +1635,6 @@ export type TokenBridgeRelayer = {
           "docs": [
             "Owner of the program as set in the [`TbrConfig`] account."
           ],
-          "writable": true,
           "signer": true,
           "relations": [
             "tbrConfig"

--- a/target/types/token_bridge_relayer.ts
+++ b/target/types/token_bridge_relayer.ts
@@ -761,7 +761,7 @@ export type TokenBridgeRelayer = {
           "name": "tbrConfig",
           "docs": [
             "Owner Config account. This program requires that the `owner` specified",
-            "in the context equals the pubkey specified in this account. Mutable."
+            "in the context equals the pubkey specified in this account."
           ],
           "writable": true,
           "pda": {
@@ -2027,6 +2027,11 @@ export type TokenBridgeRelayer = {
       "code": 6019,
       "name": "missingAssociatedTokenAccount",
       "msg": "missingAssociatedTokenAccount"
+    },
+    {
+      "code": 6020,
+      "name": "overflow",
+      "msg": "overflow"
     }
   ],
   "types": [

--- a/target/types/token_bridge_relayer.ts
+++ b/target/types/token_bridge_relayer.ts
@@ -958,13 +958,6 @@ export type TokenBridgeRelayer = {
           ]
         },
         {
-          "name": "tbrConfig",
-          "docs": [
-            "Owner Config account. This program requires that the `signer` specified",
-            "in the context equals an authorized pubkey specified in this account."
-          ]
-        },
-        {
           "name": "peer",
           "writable": true,
           "pda": {
@@ -1186,14 +1179,6 @@ export type TokenBridgeRelayer = {
         {
           "name": "chainConfig",
           "writable": true
-        },
-        {
-          "name": "tbrConfig",
-          "docs": [
-            "Program Config account. This program requires that the [`signer`] specified",
-            "in the context equals a pubkey specified in this account. Mutable,",
-            "because we will update roles depending on the operation."
-          ]
         }
       ],
       "args": [
@@ -1635,17 +1620,7 @@ export type TokenBridgeRelayer = {
           "docs": [
             "Owner of the program as set in the [`TbrConfig`] account."
           ],
-          "signer": true,
-          "relations": [
-            "tbrConfig"
-          ]
-        },
-        {
-          "name": "tbrConfig",
-          "docs": [
-            "Owner Config account. This program requires that the `owner` specified",
-            "in the context equals the `owner` pubkey specified in this account."
-          ]
+          "signer": true
         },
         {
           "name": "peer"
@@ -1802,14 +1777,6 @@ export type TokenBridgeRelayer = {
         {
           "name": "chainConfig",
           "writable": true
-        },
-        {
-          "name": "tbrConfig",
-          "docs": [
-            "Program Config account. This program requires that the [`signer`] specified",
-            "in the context equals a pubkey specified in this account. Mutable,",
-            "because we will update roles depending on the operation."
-          ]
         }
       ],
       "args": [
@@ -1857,14 +1824,6 @@ export type TokenBridgeRelayer = {
         {
           "name": "chainConfig",
           "writable": true
-        },
-        {
-          "name": "tbrConfig",
-          "docs": [
-            "Program Config account. This program requires that the [`signer`] specified",
-            "in the context equals a pubkey specified in this account. Mutable,",
-            "because we will update roles depending on the operation."
-          ]
         }
       ],
       "args": [

--- a/target/types/token_bridge_relayer.ts
+++ b/target/types/token_bridge_relayer.ts
@@ -103,6 +103,7 @@ export type TokenBridgeRelayer = {
       "accounts": [
         {
           "name": "owner",
+          "writable": true,
           "signer": true,
           "relations": [
             "tbrConfig"
@@ -116,6 +117,116 @@ export type TokenBridgeRelayer = {
             "because we will update roles depending on the operation."
           ],
           "writable": true
+        },
+        {
+          "name": "upgradeLock",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  117,
+                  112,
+                  103,
+                  114,
+                  97,
+                  100,
+                  101,
+                  32,
+                  108,
+                  111,
+                  99,
+                  107
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "programData",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  13,
+                  74,
+                  247,
+                  118,
+                  36,
+                  164,
+                  201,
+                  97,
+                  25,
+                  221,
+                  241,
+                  144,
+                  142,
+                  148,
+                  63,
+                  218,
+                  160,
+                  137,
+                  78,
+                  28,
+                  18,
+                  140,
+                  195,
+                  112,
+                  127,
+                  26,
+                  150,
+                  227,
+                  211,
+                  125,
+                  216,
+                  108
+                ]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                2,
+                168,
+                246,
+                145,
+                78,
+                136,
+                161,
+                176,
+                226,
+                16,
+                21,
+                62,
+                247,
+                99,
+                174,
+                43,
+                0,
+                194,
+                185,
+                61,
+                22,
+                193,
+                36,
+                210,
+                192,
+                83,
+                122,
+                16,
+                4,
+                128,
+                0,
+                0
+              ]
+            }
+          }
+        },
+        {
+          "name": "bpfLoaderUpgradeable",
+          "address": "BPFLoaderUpgradeab1e11111111111111111111111"
         }
       ],
       "args": []
@@ -287,7 +398,10 @@ export type TokenBridgeRelayer = {
           "writable": true
         },
         {
-          "name": "peer"
+          "name": "peer",
+          "docs": [
+            "The TBR peer (_i.e._ `data().from_address()`). We do not care about the Token Bridge peer `vaa.meta.emitter_address`."
+          ]
         },
         {
           "name": "tokenBridgeConfig"
@@ -438,10 +552,6 @@ export type TokenBridgeRelayer = {
           }
         },
         {
-          "name": "previousOwner",
-          "signer": true
-        },
-        {
           "name": "authBadgePreviousOwner",
           "writable": true,
           "pda": {
@@ -476,6 +586,30 @@ export type TokenBridgeRelayer = {
             "because we will update roles depending on the operation."
           ],
           "writable": true
+        },
+        {
+          "name": "upgradeLock",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  117,
+                  112,
+                  103,
+                  114,
+                  97,
+                  100,
+                  101,
+                  32,
+                  108,
+                  111,
+                  99,
+                  107
+                ]
+              }
+            ]
+          }
         },
         {
           "name": "programData",
@@ -1073,7 +1207,12 @@ export type TokenBridgeRelayer = {
     {
       "name": "submitOwnerTransferRequest",
       "docs": [
-        "Updates the owner account. This needs to be either cancelled or approved."
+        "Updates the owner account. This needs to be either cancelled or approved.",
+        "",
+        "For safety reasons, transferring ownership is a 2-step process. This first step is to set the",
+        "new owner, and the second step is for the new owner to claim the ownership.",
+        "This is to prevent a situation where the ownership is transferred to an",
+        "address that is not able to claim the ownership (by mistake)."
       ],
       "discriminator": [
         99,
@@ -1116,6 +1255,116 @@ export type TokenBridgeRelayer = {
               }
             ]
           }
+        },
+        {
+          "name": "upgradeLock",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  117,
+                  112,
+                  103,
+                  114,
+                  97,
+                  100,
+                  101,
+                  32,
+                  108,
+                  111,
+                  99,
+                  107
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "programData",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  13,
+                  74,
+                  247,
+                  118,
+                  36,
+                  164,
+                  201,
+                  97,
+                  25,
+                  221,
+                  241,
+                  144,
+                  142,
+                  148,
+                  63,
+                  218,
+                  160,
+                  137,
+                  78,
+                  28,
+                  18,
+                  140,
+                  195,
+                  112,
+                  127,
+                  26,
+                  150,
+                  227,
+                  211,
+                  125,
+                  216,
+                  108
+                ]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                2,
+                168,
+                246,
+                145,
+                78,
+                136,
+                161,
+                176,
+                226,
+                16,
+                21,
+                62,
+                247,
+                99,
+                174,
+                43,
+                0,
+                194,
+                185,
+                61,
+                22,
+                193,
+                36,
+                210,
+                192,
+                83,
+                122,
+                16,
+                4,
+                128,
+                0,
+                0
+              ]
+            }
+          }
+        },
+        {
+          "name": "bpfLoaderUpgradeable",
+          "address": "BPFLoaderUpgradeab1e11111111111111111111111"
         }
       ],
       "args": [
@@ -2059,6 +2308,11 @@ export type TokenBridgeRelayer = {
       "name": "seedPrefixTemporary",
       "type": "bytes",
       "value": "[116, 109, 112]"
+    },
+    {
+      "name": "seedPrefixUpgradeLock",
+      "type": "bytes",
+      "value": "[117, 112, 103, 114, 97, 100, 101, 32, 108, 111, 99, 107]"
     }
   ]
 };


### PR DESCRIPTION
- Allow to create accounts by hand even if they're squatted.
- Refactor the program ownership transfer so that we only need the new owner's signature when accepting the transfer.
- Check both the chain ID and the peer address in case of an inbound transfer