### PR TITLE
Evm: adds gas token observer

### DIFF
--- a/connect/platforms/evm/src/automatic.ts
+++ b/connect/platforms/evm/src/automatic.ts
@@ -65,8 +65,6 @@ export class AutomaticTokenBridgeV3EVM<N extends Network, C extends EvmChains>
 
     this.tbr = Tbrv3.connectUnknown(
       wrapEthersProvider(provider),
-      network,
-      chain,
       new EvmAddress(address)
     );
 

--- a/deployment/config/read-configuration.ts
+++ b/deployment/config/read-configuration.ts
@@ -46,10 +46,7 @@ const readChainConfig: SolanaScriptCb & EvmScriptCb = async function (
     const tbrv3ProxyAddress = new EvmAddress(getContractAddress("TbrV3Proxies", operatingChainId));
     const tbr = Tbrv3.connectUnknown(
       wrapEthersProvider(provider),
-      operatingChain.network,
-      operatingChain.name,
       tbrv3ProxyAddress,
-      undefined
     );
 
     const otherChains = loadTbrPeers(operatingChain).map(({chainId}) => chainId);

--- a/deployment/config/read-configuration.ts
+++ b/deployment/config/read-configuration.ts
@@ -7,7 +7,7 @@ import { dependencies, getContractAddress, loadTbrPeers } from '../helpers/env.j
 import { inspect } from 'util';
 import { getProvider, runOnEvmsSequentially, wrapEthersProvider } from '../helpers/evm.js';
 import type { EvmScriptCb } from '../helpers/interfaces.js';
-import { Tbrv3, ConfigQuery, SupportedChain } from '@xlabs-xyz/evm-arbitrary-token-transfers';
+import { Tbrv3, ConfigQuery } from '@xlabs-xyz/evm-arbitrary-token-transfers';
 import { EvmAddress } from '@wormhole-foundation/sdk-evm';
 
 const readChainConfig: SolanaScriptCb & EvmScriptCb = async function (
@@ -57,19 +57,19 @@ const readChainConfig: SolanaScriptCb & EvmScriptCb = async function (
     for (const chainId of otherChains) {
       const canonicalPeerQuery = {
         query: "CanonicalPeer",
-        chain: chainIdToChain(chainId) as SupportedChain
+        chain: chainIdToChain(chainId)
       } as const satisfies ConfigQuery;
       const maxGasDropoffQuery = {
         query: "MaxGasDropoff",
-        chain: chainIdToChain(chainId) as SupportedChain
+        chain: chainIdToChain(chainId)
       } as const satisfies ConfigQuery;
       const isPausedQuery = {
         query: "IsChainPaused",
-        chain: chainIdToChain(chainId) as SupportedChain
+        chain: chainIdToChain(chainId)
       } as const satisfies ConfigQuery;
       const baseFeeQuery = {
         query: "BaseFee",
-        chain: chainIdToChain(chainId) as SupportedChain
+        chain: chainIdToChain(chainId)
       } as const satisfies ConfigQuery;
 
       queries.push(canonicalPeerQuery);

--- a/deployment/evm/configure-fee-and-dropoff.ts
+++ b/deployment/evm/configure-fee-and-dropoff.ts
@@ -17,8 +17,6 @@ evm.runOnEvms("configure-fee-and-dropoff", async (chain, signer, log) => {
   const tbrv3ProxyAddress = new EvmAddress(getContractAddress("TbrV3Proxies", chainToChainId(chain.name)));
   const tbrv3 = Tbrv3.connectUnknown(
     wrapEthersProvider(signer.provider!),
-    chain.network,
-    chain.name,
     tbrv3ProxyAddress
   );
   const peers = loadTbrPeers(chain);

--- a/deployment/evm/configure-fee-and-dropoff.ts
+++ b/deployment/evm/configure-fee-and-dropoff.ts
@@ -4,8 +4,8 @@ import {
   getContractAddress,
   loadTbrPeers,
 } from "../helpers/index.js";
-import { chainIdToChain, chainToChainId, encoding } from "@wormhole-foundation/sdk-base";
-import { SupportedChain, Tbrv3 } from "@xlabs-xyz/evm-arbitrary-token-transfers";
+import { Chain, chainIdToChain, chainToChainId, encoding } from "@wormhole-foundation/sdk-base";
+import { Tbrv3 } from "@xlabs-xyz/evm-arbitrary-token-transfers";
 import { EvmTbrV3Config } from "../config/config.types.js";
 import { EvmAddress } from "@wormhole-foundation/sdk-evm";
 import { wrapEthersProvider } from "../helpers/evm.js";
@@ -25,7 +25,7 @@ evm.runOnEvms("configure-fee-and-dropoff", async (chain, signer, log) => {
 
   const queries = [];
   for (const otherTbrv3 of peers) {
-    const otherTbrv3Chain = chainIdToChain(otherTbrv3.chainId) as SupportedChain;
+    const otherTbrv3Chain = chainIdToChain(otherTbrv3.chainId);
 
     queries.push({query: "BaseFee", chain: otherTbrv3Chain} as const);
     queries.push({query: "MaxGasDropoff", chain: otherTbrv3Chain} as const);
@@ -33,8 +33,8 @@ evm.runOnEvms("configure-fee-and-dropoff", async (chain, signer, log) => {
 
   const configValues = await tbrv3.query([{query: "ConfigQueries", queries}]);
 
-  const currentState: Map<SupportedChain, {baseFee: number; maxGasDropoff: number}> = new Map(peers.map(({chainId}) => [
-    chainIdToChain(chainId) as SupportedChain,
+  const currentState: Map<Chain, {baseFee: number; maxGasDropoff: number}> = new Map(peers.map(({chainId}) => [
+    chainIdToChain(chainId),
     {} as any
   ]));
   for (const config of configValues) {
@@ -51,7 +51,7 @@ evm.runOnEvms("configure-fee-and-dropoff", async (chain, signer, log) => {
     const peerChainCfg = await getChainConfig<EvmTbrV3Config>("tbr-v3", otherTbrv3.chainId);
     const desiredBaseFee = Number(peerChainCfg.relayFee);
     const desiredMaxGasDropoff = Number(peerChainCfg.maxGasDropoff);
-    const otherTbrv3Chain = chainIdToChain(otherTbrv3.chainId) as SupportedChain;
+    const otherTbrv3Chain = chainIdToChain(otherTbrv3.chainId);
     const chainState = currentState.get(otherTbrv3Chain)!;
     // schedule update
     if (chainState.baseFee !== desiredBaseFee) {

--- a/deployment/evm/read-configured-fee-and-dropoff.ts
+++ b/deployment/evm/read-configured-fee-and-dropoff.ts
@@ -17,8 +17,6 @@ evm.runOnEvmsSequentially("read-configured-fee-and-dropoff", async (operatingCha
   const tbrv3ProxyAddress = new EvmAddress(getContractAddress("TbrV3Proxies", chainToChainId(operatingChain.name)));
   const tbrv3 = Tbrv3.connectUnknown(
     wrapEthersProvider(signer.provider!),
-    operatingChain.network,
-    operatingChain.name,
     tbrv3ProxyAddress
   );
   const peers = loadTbrPeers(operatingChain);

--- a/deployment/evm/read-configured-fee-and-dropoff.ts
+++ b/deployment/evm/read-configured-fee-and-dropoff.ts
@@ -5,7 +5,7 @@ import {
 } from "../helpers/index.js";
 import { chainIdToChain, chainToChainId } from "@wormhole-foundation/sdk-base";
 import { EvmAddress } from "@wormhole-foundation/sdk-evm";
-import { SupportedChain, Tbrv3 } from "@xlabs-xyz/evm-arbitrary-token-transfers";
+import { Tbrv3 } from "@xlabs-xyz/evm-arbitrary-token-transfers";
 import { wrapEthersProvider } from "../helpers/evm.js";
   
 /**
@@ -26,7 +26,7 @@ evm.runOnEvmsSequentially("read-configured-fee-and-dropoff", async (operatingCha
 
   let queries = [];
   for (const otherTbrv3 of peers) {
-    const otherTbrv3Chain = chainIdToChain(otherTbrv3.chainId) as SupportedChain;
+    const otherTbrv3Chain = chainIdToChain(otherTbrv3.chainId);
 
     queries.push({query: "BaseFee", chain: otherTbrv3Chain} as const);
     queries.push({query: "MaxGasDropoff", chain: otherTbrv3Chain} as const);

--- a/deployment/evm/register-peers.ts
+++ b/deployment/evm/register-peers.ts
@@ -5,7 +5,7 @@ import {
 } from "../helpers/index.js";
 import { toUniversal } from "@wormhole-foundation/sdk-definitions";
 import { chainIdToChain, chainToChainId, encoding } from "@wormhole-foundation/sdk-base";
-import { ConfigCommand, ConfigQuery, SupportedChain, Tbrv3 } from "@xlabs-xyz/evm-arbitrary-token-transfers";
+import { ConfigCommand, ConfigQuery, Tbrv3 } from "@xlabs-xyz/evm-arbitrary-token-transfers";
 import { EvmAddress } from "@wormhole-foundation/sdk-evm";
 import { wrapEthersProvider } from "../helpers/evm.js";
 
@@ -26,7 +26,7 @@ evm.runOnEvms("register-peers", async (operatingChain, signer, log) => {
 
   const queries = [];
   for (const otherTbrv3 of peers) {
-    const otherTbrv3Chain = chainIdToChain(otherTbrv3.chainId) as SupportedChain;
+    const otherTbrv3Chain = chainIdToChain(otherTbrv3.chainId);
     const peerAddress = toUniversal(otherTbrv3Chain, otherTbrv3.address);
     queries.push({query: "IsPeer", chain: otherTbrv3Chain, address: peerAddress} as const satisfies ConfigQuery);
   }

--- a/deployment/evm/register-peers.ts
+++ b/deployment/evm/register-peers.ts
@@ -18,8 +18,6 @@ evm.runOnEvms("register-peers", async (operatingChain, signer, log) => {
   const tbrv3ProxyAddress = new EvmAddress(getContractAddress("TbrV3Proxies", chainToChainId(operatingChain.name)));
   const tbrv3 = Tbrv3.connectUnknown(
     wrapEthersProvider(signer.provider!),
-    operatingChain.network,
-    operatingChain.name,
     tbrv3ProxyAddress
   );
   const peers = loadTbrPeers(operatingChain);

--- a/deployment/evm/set-canonical-peer.ts
+++ b/deployment/evm/set-canonical-peer.ts
@@ -5,8 +5,8 @@ import {
   loadTbrPeers,
 } from "../helpers/index.js";
 import { toUniversal } from "@wormhole-foundation/sdk-definitions";
-import { chainIdToChain, chainToChainId, encoding } from "@wormhole-foundation/sdk-base";
-import { ConfigCommand, ConfigQuery, SupportedChain, Tbrv3 } from "@xlabs-xyz/evm-arbitrary-token-transfers";
+import { Chain, chainIdToChain, chainToChainId, encoding } from "@wormhole-foundation/sdk-base";
+import { ConfigCommand, ConfigQuery, Tbrv3 } from "@xlabs-xyz/evm-arbitrary-token-transfers";
 import { EvmAddress } from "@wormhole-foundation/sdk-evm";
 import { wrapEthersProvider } from "../helpers/evm.js";
 
@@ -34,11 +34,11 @@ evm.runOnEvms("set-canonical-peer", async (operatingChain, signer, log) => {
 
   const queries = [];
   for (const otherTbrv3 of peers) {
-    const otherTbrv3Chain = chainIdToChain(otherTbrv3.chainId) as SupportedChain;
+    const otherTbrv3Chain = chainIdToChain(otherTbrv3.chainId);
     queries.push({query: "CanonicalPeer", chain: otherTbrv3Chain} as const satisfies ConfigQuery);
   }
   const currentCanonicalPeers = await tbrv3.query([{query: "ConfigQueries", queries}]);
-  const getCanonicalPeerAddress = (chain: SupportedChain) => {
+  const getCanonicalPeerAddress = (chain: Chain) => {
     return peers.find(({chainId}) => chainIdToChain(chainId) === chain)!.address;
   }
 

--- a/deployment/evm/set-canonical-peer.ts
+++ b/deployment/evm/set-canonical-peer.ts
@@ -16,16 +16,10 @@ import { wrapEthersProvider } from "../helpers/evm.js";
  * If no peer is registered for a chain, it will be set as the canonical peer.
  */
 evm.runOnEvms("set-canonical-peer", async (operatingChain, signer, log) => {
-  // HACK! resolveWrappedToken does not seem to work for CELO native currency.
-  const gasTokenAddress = operatingChain.name === "Celo" ? new EvmAddress(getDependencyAddress("initGasToken", operatingChain)) : undefined;
-
   const tbrv3ProxyAddress = new EvmAddress(getContractAddress("TbrV3Proxies", chainToChainId(operatingChain.name)));
   const tbrv3 = Tbrv3.connectUnknown(
     wrapEthersProvider(signer.provider!),
-    operatingChain.network,
-    operatingChain.name,
     tbrv3ProxyAddress,
-    gasTokenAddress
   );
 
   // WARNING: We're going to assume we have only one peer per chain in this list

--- a/deployment/evm/unpause-transfer.ts
+++ b/deployment/evm/unpause-transfer.ts
@@ -5,7 +5,7 @@ import {
   LoggerFn
 } from "../helpers/index.js";
 import { Chain, chainIdToChain, chainToChainId, encoding } from "@wormhole-foundation/sdk-base";
-import { ConfigCommand, ConfigQuery, SupportedChain, Tbrv3 } from "@xlabs-xyz/evm-arbitrary-token-transfers";
+import { ConfigCommand, ConfigQuery, Tbrv3 } from "@xlabs-xyz/evm-arbitrary-token-transfers";
 import { EvmAddress } from "@wormhole-foundation/sdk-evm";
 import { wrapEthersProvider } from "../helpers/evm.js";
 
@@ -13,7 +13,9 @@ import { wrapEthersProvider } from "../helpers/evm.js";
  * Unpause transfers for Tbrv3 contracts.
  */
 evm.runOnEvms("unpause-transfer", async (operatingChain, signer, log) => {
-  const tbrv3ProxyAddress = new EvmAddress(getContractAddress("TbrV3Proxies", chainToChainId(operatingChain.name)));
+  const tbrv3ProxyAddress = new EvmAddress(
+    getContractAddress("TbrV3Proxies", chainToChainId(operatingChain.name))
+  );
   const peers = loadTbrPeers(operatingChain);
   const tbrv3 = Tbrv3.connectUnknown(
     wrapEthersProvider(signer.provider!),
@@ -23,7 +25,10 @@ evm.runOnEvms("unpause-transfer", async (operatingChain, signer, log) => {
   );
 
   // TODO: accept specific chains to pause or unpause instead of doing an ecosystem wide operation.
-  const queries = peers.map(({chainId}) => ({ query: "IsChainPaused", chain: chainIdToChain(chainId) as SupportedChain } as const satisfies ConfigQuery));
+  const queries = peers.map(({chainId}) => ({
+    query: "IsChainPaused",
+    chain: chainIdToChain(chainId)
+  } as const satisfies ConfigQuery));
   const isPausedResults = await tbrv3.query([{query: "ConfigQueries", queries}]);
 
   const pausedChains = isPausedResults.filter(({result}) => result);
@@ -46,7 +51,10 @@ evm.runOnEvms("unpause-transfer", async (operatingChain, signer, log) => {
     { command: "ConfigCommands", 
       commands,
     }])
-  const { txid } = await evm.sendTx(signer, { ...partialTx, data: encoding.hex.encode(partialTx.data, true) });
+  const { txid } = await evm.sendTx(signer, {
+    ...partialTx,
+    data: encoding.hex.encode(partialTx.data, true)
+  });
   log(`Unpause tx successful in ${txid}`);
 
 });

--- a/deployment/evm/unpause-transfer.ts
+++ b/deployment/evm/unpause-transfer.ts
@@ -19,8 +19,6 @@ evm.runOnEvms("unpause-transfer", async (operatingChain, signer, log) => {
   const peers = loadTbrPeers(operatingChain);
   const tbrv3 = Tbrv3.connectUnknown(
     wrapEthersProvider(signer.provider!),
-    operatingChain.network,
-    operatingChain.name,
     tbrv3ProxyAddress
   );
 

--- a/deployment/evm/upgrade.ts
+++ b/deployment/evm/upgrade.ts
@@ -75,18 +75,10 @@ async function upgradeProxyWithNewImplementation(
   const signer = await getSigner(operatingChain);
   const { Tbrv3 } = await import("@xlabs-xyz/evm-arbitrary-token-transfers");
 
-  // HACK! resolveWrappedToken does not seem to work for CELO native currency.
-  const gasTokenAddress = operatingChain.name === "Celo"
-    ? new EvmAddress(getDependencyAddress("initGasToken", operatingChain))
-    : undefined;
-
   const proxyAddress = new EvmAddress(getContractAddress("TbrV3Proxies", chainToChainId(operatingChain.name)));
   const tbr = Tbrv3.connectUnknown(
     wrapEthersProvider(signer.provider!),
-    operatingChain.network,
-    operatingChain.name,
     proxyAddress,
-    gasTokenAddress
   );
 
   const tx = tbr.execTx(0n, [{

--- a/deployment/test/test-transfer.ts
+++ b/deployment/test/test-transfer.ts
@@ -15,10 +15,20 @@ import {
 import { ethers } from 'ethers';
 import { getProvider, runOnEvms, sendTxCatch, wrapEthersProvider } from '../helpers/evm.js';
 import { Tbrv3, Transfer } from '@xlabs-xyz/evm-arbitrary-token-transfers';
-import { resolveWrappedToken, toUniversal, UniversalAddress } from '@wormhole-foundation/sdk-definitions';
+import {
+  resolveWrappedToken,
+  toUniversal,
+  UniversalAddress
+} from '@wormhole-foundation/sdk-definitions';
 import { Chain, chainToChainId, chainToPlatform, contracts } from '@wormhole-foundation/sdk-base';
 import { inspect } from 'util';
-import { solanaOperatingChains, getConnection, ledgerSignAndSend, runOnSolana, SolanaSigner } from '../helpers/solana.js';
+import {
+  solanaOperatingChains,
+  getConnection,
+  ledgerSignAndSend,
+  runOnSolana,
+  SolanaSigner
+} from '../helpers/solana.js';
 import { EvmAddress } from '@wormhole-foundation/sdk-evm';
 import { PublicKey, SystemProgram, TransactionInstruction } from '@solana/web3.js';
 import {
@@ -57,7 +67,12 @@ const DEFAULT_MAX_FEE_SOL = 5000;
 const DEFAULT_MAX_FEE_KLAMPORTS = 5000000;
 
 
-async function approve(tokenAddress: string, spenderAddress: string, amount: number, signer: ethers.Signer) {
+async function approve(
+  tokenAddress: string,
+  spenderAddress: string,
+  amount: number,
+  signer: ethers.Signer
+) {
   const erc20Abi = [
     "function approve(address spender, uint256 amount) public returns (bool)"
   ];
@@ -76,7 +91,8 @@ async function approve(tokenAddress: string, spenderAddress: string, amount: num
  * - SOLANA_RECIPIENT_ADDRESS: Solana address to send tokens to
  *
  * Optionally, you can define the following:
- * - FLIP_ROUTES: set to true if you want to transfer the tokens in the opposite direction. Use after all the relays were redeemed to ensure you have the tokens.
+ * - FLIP_ROUTES: set to true if you want to transfer the tokens in the opposite direction.
+ *   Use after all the relays were redeemed to ensure you have the tokens.
  * - EVM_WALLET_KEY: EVM override for private key
  * - SOLANA_WALLET_KEY: Solana override for private key
  */
@@ -94,7 +110,9 @@ async function run() {
   })) : uniqueTestTransfers;
 
   const sendTransaction: EvmScriptCb & SolanaScriptCb =  async (chain, signer, logFn) => {
-    const transfers = tests.filter((testTransfer) => !testTransfer.skip && testTransfer.fromChain === chain.name);
+    const transfers = tests.filter((testTransfer) =>
+      !testTransfer.skip && testTransfer.fromChain === chain.name
+    );
     logFn(`Transfers from ${chain.name}: ${transfers.length}`);
 
     const promises = transfers.map(async (testTransfer) => {
@@ -128,17 +146,28 @@ async function run() {
   console.log(`Process ${processName} finished after ${timeMs} miliseconds`);
 }
 
-async function getLocalToken(tokenAddress: UniversalAddress, tokenChain: Chain, localChain: EvmChainInfo | SolanaChainInfo): Promise<UniversalAddress> {
+async function getLocalToken(
+  tokenAddress: UniversalAddress,
+  tokenChain: Chain,
+  localChain: EvmChainInfo | SolanaChainInfo
+): Promise<UniversalAddress> {
   if (localChain.name === tokenChain) {
     return tokenAddress;
   }
 
-  const tokenBridgeAddress: string = contracts.tokenBridge(localChain.network, localChain.name as any);
+  const tokenBridgeAddress: string = contracts.tokenBridge(
+    localChain.network,
+    localChain.name as any
+  );
   if (localChain.name === "Solana") {
-    if (tokenChain === "Solana") {
-      return tokenAddress;
-    }
-    return toUniversal("Solana", deriveWrappedMintKey(tokenBridgeAddress, chainToChainId(tokenChain), tokenAddress.toUint8Array()).toBytes());
+    return toUniversal(
+      "Solana",
+      deriveWrappedMintKey(
+        tokenBridgeAddress,
+        chainToChainId(tokenChain),
+        tokenAddress.toUint8Array()
+      ).toBytes()
+    );
   }
 
   const provider = getProvider(localChain);

--- a/deployment/test/test-transfer.ts
+++ b/deployment/test/test-transfer.ts
@@ -222,8 +222,6 @@ async function sendEvmTestTransaction(
     const provider = getProvider(chain);
     const tbrv3 = Tbrv3.connectUnknown(
       wrapEthersProvider(provider!),
-      chain.network,
-      chain.name,
       tbrv3ProxyAddress
     );
 

--- a/deployment/test/test-transfer.ts
+++ b/deployment/test/test-transfer.ts
@@ -14,7 +14,7 @@ import {
 } from '../helpers/index.js';
 import { ethers } from 'ethers';
 import { getProvider, runOnEvms, sendTxCatch, wrapEthersProvider } from '../helpers/evm.js';
-import { SupportedChain, Tbrv3, Transfer } from '@xlabs-xyz/evm-arbitrary-token-transfers';
+import { Tbrv3, Transfer } from '@xlabs-xyz/evm-arbitrary-token-transfers';
 import { resolveWrappedToken, toUniversal, UniversalAddress } from '@wormhole-foundation/sdk-definitions';
 import { Chain, chainToChainId, chainToPlatform, contracts } from '@wormhole-foundation/sdk-base';
 import { inspect } from 'util';
@@ -133,7 +133,7 @@ async function getLocalToken(tokenAddress: UniversalAddress, tokenChain: Chain, 
     return tokenAddress;
   }
 
-  const tokenBridgeAddress = contracts.tokenBridge(localChain.network, localChain.name as Exclude<SupportedChain, "Sepolia" | "BaseSepolia" | "OptimismSepolia">);
+  const tokenBridgeAddress: string = contracts.tokenBridge(localChain.network, localChain.name as any);
   if (localChain.name === "Solana") {
     if (tokenChain === "Solana") {
       return tokenAddress;
@@ -155,7 +155,7 @@ async function getLocalToken(tokenAddress: UniversalAddress, tokenChain: Chain, 
 function getNativeWrappedToken(chain: EvmChainInfo) {
   let token;
   try {
-    ([, { address: token }] = resolveWrappedToken(chain.network, chain.name as Exclude<SupportedChain, "Solana">, "native"));
+    ([, { address: token }] = resolveWrappedToken(chain.network, chain.name, "native"));
   } catch {}
   if (token === undefined) {
     throw new Error(`Could not find gas token for chain ${chain.name}`);
@@ -214,7 +214,7 @@ async function sendEvmTestTransaction(
 
       const [{ result: isChainSupported }] = await tbrv3.query([
         {
-          query: "ConfigQueries", queries: [{ query: "IsChainSupported", chain: targetChain.name as SupportedChain }]
+          query: "ConfigQueries", queries: [{ query: "IsChainSupported", chain: targetChain.name }]
         }
       ]);
 
@@ -232,7 +232,7 @@ async function sendEvmTestTransaction(
         await tbrv3.relayingFee({
           tokens: [inputToken],
           transferRequests: [{
-            targetChain: targetChain.name as SupportedChain,
+            targetChain: targetChain.name,
             gasDropoff,
           }],
         })
@@ -249,7 +249,7 @@ async function sendEvmTestTransaction(
           inputAmountInAtomic,
           gasDropoff,
           recipient: {
-            chain: targetChain.name as SupportedChain,
+            chain: targetChain.name,
             address: toUniversal(targetChain.name as Chain, address),
           },
           inputToken,

--- a/evm/src/assets/TbrConfig.sol
+++ b/evm/src/assets/TbrConfig.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.25;
 
-import { 
+import {
   AccessControl,
   Role,
   NotAuthorized,
@@ -100,7 +100,7 @@ abstract contract TbrConfig is TbrBase, AccessControl {
       }
       else
         revert InvalidConfigCommand(command);
-      
+
     }
     return offset;
   }
@@ -166,7 +166,7 @@ abstract contract TbrConfig is TbrBase, AccessControl {
 
   function _setFeeRecipient(address newFeeRecipient) internal {
     senderAtLeastAdmin();
-    
+
     ConfigState storage state = configState();
     address oldFeeRecipient = state.feeRecipient;
     state.feeRecipient = payable(newFeeRecipient);

--- a/evm/src/assets/TbrDispatcher.sol
+++ b/evm/src/assets/TbrDispatcher.sol
@@ -102,6 +102,8 @@ abstract contract TbrDispatcher is RawDispatcher, TbrConfig, TbrUser, SweepToken
         (result, offset) = _batchConfigQueries(data, offset);
       else if (query == ALLOWANCE_TOKEN_BRIDGE_ID)
         (result, offset) = _allowanceTokenBridge(data, offset);
+      else if (query == GAS_TOKEN_ID)
+        result = abi.encodePacked(gasToken);
       else {
         bool dispatched;
         (dispatched, result, offset) = dispatchQueryAccessControl(data, offset, query);

--- a/evm/src/assets/TbrDispatcher.sol
+++ b/evm/src/assets/TbrDispatcher.sol
@@ -104,6 +104,8 @@ abstract contract TbrDispatcher is RawDispatcher, TbrConfig, TbrUser, SweepToken
         (result, offset) = _allowanceTokenBridge(data, offset);
       else if (query == GAS_TOKEN_ID)
         result = abi.encodePacked(gasToken);
+      else if (query == GAS_TOKEN_ALLOWANCE_TOKEN_BRIDGE_ID)
+        result = abi.encodePacked(_allowanceTokenBridgeImpl(address(gasToken)));
       else {
         bool dispatched;
         (dispatched, result, offset) = dispatchQueryAccessControl(data, offset, query);

--- a/evm/src/assets/TbrIds.sol
+++ b/evm/src/assets/TbrIds.sol
@@ -20,6 +20,7 @@ uint8 constant RELAY_FEE_ID = 0x80;
 uint8 constant BASE_RELAYING_CONFIG_ID = 0x81;
 uint8 constant CONFIG_QUERIES_ID = 0x82;
 uint8 constant ALLOWANCE_TOKEN_BRIDGE_ID = 0x83;
+uint8 constant GAS_TOKEN_ID = 0x84;
 
 // ----------- Config Ids -----------
 

--- a/evm/src/assets/TbrIds.sol
+++ b/evm/src/assets/TbrIds.sol
@@ -21,6 +21,7 @@ uint8 constant BASE_RELAYING_CONFIG_ID = 0x81;
 uint8 constant CONFIG_QUERIES_ID = 0x82;
 uint8 constant ALLOWANCE_TOKEN_BRIDGE_ID = 0x83;
 uint8 constant GAS_TOKEN_ID = 0x84;
+uint8 constant GAS_TOKEN_ALLOWANCE_TOKEN_BRIDGE_ID = 0x85;
 
 // ----------- Config Ids -----------
 

--- a/evm/src/assets/TbrUser.sol
+++ b/evm/src/assets/TbrUser.sol
@@ -500,13 +500,19 @@ abstract contract TbrUser is TbrBase {
   function _allowanceTokenBridge(
     bytes calldata data,
     uint offset
-  ) internal view returns (bytes memory, uint) { unchecked {
+  ) internal view returns (bytes memory, uint) {
     address token; uint retOffset;
     (token, retOffset) = data.asAddressCdUnchecked(offset);
-    uint256 allowance = IERC20Metadata(token).allowance(address(this), address(tokenBridge));
+    uint256 allowance = _allowanceTokenBridgeImpl(token);
 
     return (abi.encodePacked(allowance), retOffset);
-  }}
+  }
+
+  function _allowanceTokenBridgeImpl(
+    address token
+  ) internal view returns (uint256) {
+    return IERC20Metadata(token).allowance(address(this), address(tokenBridge));
+  }
 
   function _completeTransfer(
     bytes calldata data,

--- a/evm/test/Base.t.sol
+++ b/evm/test/Base.t.sol
@@ -27,8 +27,6 @@ contract BaseTest is TbrTestBase {
 
     bytes memory result = tbr.invokeStaticTbr(
       abi.encodePacked(
-        tbr.get1959.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         GAS_TOKEN_ID
       )
     );
@@ -44,8 +42,6 @@ contract BaseTest is TbrTestBase {
 
     bytes memory result = tbr.invokeStaticTbr(
       abi.encodePacked(
-        tbr.get1959.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         GAS_TOKEN_ID
       )
     );

--- a/evm/test/Base.t.sol
+++ b/evm/test/Base.t.sol
@@ -2,16 +2,58 @@
 
 pragma solidity ^0.8.25;
 
-import { 
-  ChainIsNotRegistered, 
+import {
+  ChainIsNotRegistered,
   InvalidChainId,
   PeerIsZeroAddress,
   ChainNotSupportedByTokenBridge
 } from "tbr/assets/TbrBase.sol";
-import { TbrTestBase } from "./utils/TbrTestBase.sol";
+import { TbrTestBase, InvokeTbr } from "./utils/TbrTestBase.sol";
+import { TbrExposer } from "./utils/TbrExposer.sol";
+import { Tbr } from "tbr/Tbr.sol";
+import "tbr/assets/TbrIds.sol";
+import { BytesParsing } from "wormhole-sdk/libraries/BytesParsing.sol";
+import { IWETH } from "wormhole-sdk/interfaces/token/IWETH.sol";
+
 import { makeBytes32 } from "./utils/utils.sol";
 
 contract BaseTest is TbrTestBase {
+  using BytesParsing for bytes;
+  using InvokeTbr for TbrExposer;
+
+  function testGasToken() public {
+    IWETH someGasToken = IWETH(makeAddr("gasToken"));
+    TbrExposer tbr = deployInstrumentedTbr(someGasToken);
+
+    bytes memory result = tbr.invokeStaticTbr(
+      abi.encodePacked(
+        tbr.get1959.selector,
+        DISPATCHER_PROTOCOL_VERSION0,
+        GAS_TOKEN_ID
+      )
+    );
+
+    (address readGasToken, ) = result.asAddressMemUnchecked(0);
+    assertEq(readGasToken, address(someGasToken));
+    assertEq(result.length, 20);
+  }
+
+  function testGasToken_zeroAddress() public {
+    IWETH someGasToken = IWETH(address(0));
+    TbrExposer tbr = deployInstrumentedTbr(someGasToken);
+
+    bytes memory result = tbr.invokeStaticTbr(
+      abi.encodePacked(
+        tbr.get1959.selector,
+        DISPATCHER_PROTOCOL_VERSION0,
+        GAS_TOKEN_ID
+      )
+    );
+
+    (address readGasToken, ) = result.asAddressMemUnchecked(0);
+    assertEq(readGasToken, address(someGasToken));
+    assertEq(result.length, 20);
+  }
 
   function testAddPeer(bytes32 peer, bytes32 anotherPeer) public {
     vm.assume(peer != bytes32(0));

--- a/evm/test/ConfigTest.t.sol
+++ b/evm/test/ConfigTest.t.sol
@@ -6,21 +6,23 @@ import { InvalidConfigCommand, InvalidConfigQuery } from "tbr/assets/TbrConfig.s
 import { NotAuthorized } from "wormhole-sdk/components/dispatcher/AccessControl.sol";
 import { BytesParsing } from "wormhole-sdk/libraries/BytesParsing.sol";
 import { ChainIsNotRegistered } from "tbr/assets/TbrBase.sol";
-import { TbrTestBase } from "./utils/TbrTestBase.sol";
+import { Tbr } from "tbr/Tbr.sol";
+import { TbrTestBase, InvokeTbr } from "./utils/TbrTestBase.sol";
 import { makeBytes32 } from "./utils/utils.sol";
 import "tbr/assets/TbrIds.sol";
 
 contract ConfigTest is TbrTestBase {
   using BytesParsing for bytes;
+  using InvokeTbr for Tbr;
 
   function addCanonicalPeer(uint16 peerChain, bytes32 peer) internal {
     uint8 commandCount = 1;
-    invokeTbr(
+    tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector, 
-        DISPATCHER_PROTOCOL_VERSION0, 
+        tbr.exec768.selector,
+        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_ID,
-        commandCount, 
+        commandCount,
         UPDATE_CANONICAL_PEER_ID,
         peerChain,
         peer
@@ -34,37 +36,37 @@ contract ConfigTest is TbrTestBase {
     uint8 commandCount = 1;
 
     vm.expectRevert(NotAuthorized.selector);
-    invokeTbr(
+    tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector, 
-        DISPATCHER_PROTOCOL_VERSION0, 
+        tbr.exec768.selector,
+        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_ID,
-        commandCount, 
+        commandCount,
         ADD_PEER_ID,
-        peerChain, 
+        peerChain,
         newPeer
       )
     );
 
     vm.startPrank(owner);
-    invokeTbr(
+    tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector, 
-        DISPATCHER_PROTOCOL_VERSION0, 
+        tbr.exec768.selector,
+        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_ID,
-        commandCount, 
+        commandCount,
         ADD_PEER_ID,
-        peerChain, 
+        peerChain,
         newPeer
       )
     );
 
-    (bool isPeer, ) = invokeStaticTbr(
+    (bool isPeer, ) = tbr.invokeStaticTbr(
       abi.encodePacked(
-        tbr.get1959.selector, 
-        DISPATCHER_PROTOCOL_VERSION0, 
+        tbr.get1959.selector,
+        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_QUERIES_ID,
-        commandCount, 
+        commandCount,
         IS_PEER_ID,
         peerChain,
         newPeer
@@ -85,12 +87,12 @@ contract ConfigTest is TbrTestBase {
     vm.startPrank(owner);
     addCanonicalPeer(peerChain, newPeer);
 
-    (bool isPeer, ) = invokeStaticTbr(
+    (bool isPeer, ) = tbr.invokeStaticTbr(
       abi.encodePacked(
-        tbr.get1959.selector, 
-        DISPATCHER_PROTOCOL_VERSION0, 
+        tbr.get1959.selector,
+        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_QUERIES_ID,
-        commandCount, 
+        commandCount,
         IS_PEER_ID,
         peerChain,
         newPeer
@@ -99,28 +101,28 @@ contract ConfigTest is TbrTestBase {
 
     assertEq(isPeer, true);
 
-    (bytes32 canonicalPeer, ) = invokeStaticTbr(
+    (bytes32 canonicalPeer, ) = tbr.invokeStaticTbr(
       abi.encodePacked(
-        tbr.get1959.selector, 
-        DISPATCHER_PROTOCOL_VERSION0, 
+        tbr.get1959.selector,
+        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_QUERIES_ID,
-        commandCount, 
+        commandCount,
         CANONICAL_PEER_ID,
         peerChain
       )
     ).asBytes32MemUnchecked(0);
-    
+
     assertEq(canonicalPeer, newPeer);
 
     bytes32 anotherPeer = makeBytes32("anotherPeer");
     addCanonicalPeer(peerChain, anotherPeer);
 
-    (isPeer, ) = invokeStaticTbr(
+    (isPeer, ) = tbr.invokeStaticTbr(
       abi.encodePacked(
-        tbr.get1959.selector, 
-        DISPATCHER_PROTOCOL_VERSION0, 
+        tbr.get1959.selector,
+        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_QUERIES_ID,
-        commandCount, 
+        commandCount,
         IS_PEER_ID,
         peerChain,
         anotherPeer
@@ -129,12 +131,12 @@ contract ConfigTest is TbrTestBase {
 
     assertEq(isPeer, true);
 
-    (canonicalPeer, ) = invokeStaticTbr(
+    (canonicalPeer, ) = tbr.invokeStaticTbr(
       abi.encodePacked(
-        tbr.get1959.selector, 
-        DISPATCHER_PROTOCOL_VERSION0, 
+        tbr.get1959.selector,
+        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_QUERIES_ID,
-        commandCount, 
+        commandCount,
         CANONICAL_PEER_ID,
         peerChain
       )
@@ -149,12 +151,12 @@ contract ConfigTest is TbrTestBase {
     uint8 commandCount = 1;
 
     vm.expectRevert(NotAuthorized.selector);
-    invokeTbr(
+    tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector, 
-        DISPATCHER_PROTOCOL_VERSION0, 
+        tbr.exec768.selector,
+        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_ID,
-        commandCount, 
+        commandCount,
         UPDATE_MAX_GAS_DROPOFF_ID,
         chainId,
         maxGasDropoff
@@ -165,12 +167,12 @@ contract ConfigTest is TbrTestBase {
     vm.expectRevert(
       abi.encodeWithSelector(ChainIsNotRegistered.selector, chainId)
     );
-    invokeTbr(
+    tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector, 
-        DISPATCHER_PROTOCOL_VERSION0, 
+        tbr.exec768.selector,
+        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_ID,
-        commandCount, 
+        commandCount,
         UPDATE_MAX_GAS_DROPOFF_ID,
         chainId,
         maxGasDropoff
@@ -181,24 +183,24 @@ contract ConfigTest is TbrTestBase {
     addCanonicalPeer(chainId, makeBytes32("peer"));
 
     vm.prank(admin);
-    invokeTbr(
+    tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector, 
-        DISPATCHER_PROTOCOL_VERSION0, 
+        tbr.exec768.selector,
+        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_ID,
-        commandCount, 
+        commandCount,
         UPDATE_MAX_GAS_DROPOFF_ID,
         chainId,
         maxGasDropoff
       )
     );
 
-    (uint32 maxGasDropoff_, ) = invokeStaticTbr(
+    (uint32 maxGasDropoff_, ) = tbr.invokeStaticTbr(
       abi.encodePacked(
-        tbr.get1959.selector, 
-        DISPATCHER_PROTOCOL_VERSION0, 
+        tbr.get1959.selector,
+        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_QUERIES_ID,
-        commandCount, 
+        commandCount,
         MAX_GAS_DROPOFF_ID,
         chainId
       )
@@ -212,35 +214,35 @@ contract ConfigTest is TbrTestBase {
     uint8 commandCount = 1;
 
     vm.expectRevert(NotAuthorized.selector);
-    invokeTbr(
+    tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector, 
-        DISPATCHER_PROTOCOL_VERSION0, 
+        tbr.exec768.selector,
+        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_ID,
-        commandCount, 
+        commandCount,
         UPDATE_FEE_RECIPIENT_ID,
         newFeeRecipient
       )
     );
 
     vm.prank(admin);
-    invokeTbr(
+    tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector, 
-        DISPATCHER_PROTOCOL_VERSION0, 
+        tbr.exec768.selector,
+        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_ID,
-        commandCount, 
+        commandCount,
         UPDATE_FEE_RECIPIENT_ID,
         newFeeRecipient
       )
     );
 
-    (address newFeeRecipient_, ) = invokeStaticTbr(
+    (address newFeeRecipient_, ) = tbr.invokeStaticTbr(
       abi.encodePacked(
-        tbr.get1959.selector, 
-        DISPATCHER_PROTOCOL_VERSION0, 
+        tbr.get1959.selector,
+        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_QUERIES_ID,
-        commandCount, 
+        commandCount,
         FEE_RECIPIENT_ID
       )
     ).asAddressMemUnchecked(0);
@@ -254,13 +256,13 @@ contract ConfigTest is TbrTestBase {
     uint16 chainId = EVM_CHAIN_ID;
 
     vm.expectRevert(NotAuthorized.selector);
-    invokeTbr(
+    tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector, 
-        DISPATCHER_PROTOCOL_VERSION0, 
+        tbr.exec768.selector,
+        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_ID,
-        commandCount, 
-        UPDATE_BASE_FEE_ID, 
+        commandCount,
+        UPDATE_BASE_FEE_ID,
         chainId,
         newRelayFee
       )
@@ -270,13 +272,13 @@ contract ConfigTest is TbrTestBase {
     vm.expectRevert(
       abi.encodeWithSelector(ChainIsNotRegistered.selector, chainId)
     );
-    invokeTbr(
+    tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector, 
-        DISPATCHER_PROTOCOL_VERSION0, 
+        tbr.exec768.selector,
+        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_ID,
-        commandCount, 
-        UPDATE_BASE_FEE_ID, 
+        commandCount,
+        UPDATE_BASE_FEE_ID,
         chainId,
         newRelayFee
       )
@@ -286,24 +288,24 @@ contract ConfigTest is TbrTestBase {
     addCanonicalPeer(chainId, makeBytes32("peer"));
 
     vm.prank(admin);
-    invokeTbr(
+    tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector, 
-        DISPATCHER_PROTOCOL_VERSION0, 
+        tbr.exec768.selector,
+        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_ID,
-        commandCount, 
-        UPDATE_BASE_FEE_ID, 
+        commandCount,
+        UPDATE_BASE_FEE_ID,
         chainId,
         newRelayFee
       )
     );
 
-    (uint32 newRelayFee_, ) = invokeStaticTbr(
+    (uint32 newRelayFee_, ) = tbr.invokeStaticTbr(
       abi.encodePacked(
-        tbr.get1959.selector, 
-        DISPATCHER_PROTOCOL_VERSION0, 
+        tbr.get1959.selector,
+        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_QUERIES_ID,
-        commandCount, 
+        commandCount,
         BASE_FEE_ID,
         chainId
       )
@@ -318,12 +320,12 @@ contract ConfigTest is TbrTestBase {
     uint8 commandCount = 1;
 
     vm.expectRevert(NotAuthorized.selector);
-    invokeTbr(
+    tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector, 
-        DISPATCHER_PROTOCOL_VERSION0, 
+        tbr.exec768.selector,
+        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_ID,
-        commandCount, 
+        commandCount,
         PAUSE_CHAIN_ID,
         chainId,
         paused
@@ -334,12 +336,12 @@ contract ConfigTest is TbrTestBase {
     vm.expectRevert(
       abi.encodeWithSelector(ChainIsNotRegistered.selector, chainId)
     );
-    invokeTbr(
+    tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector, 
-        DISPATCHER_PROTOCOL_VERSION0, 
+        tbr.exec768.selector,
+        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_ID,
-        commandCount, 
+        commandCount,
         PAUSE_CHAIN_ID,
         chainId,
         paused
@@ -350,24 +352,24 @@ contract ConfigTest is TbrTestBase {
     addCanonicalPeer(chainId, makeBytes32("peer"));
 
     vm.prank(admin);
-    invokeTbr(
+    tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector, 
-        DISPATCHER_PROTOCOL_VERSION0, 
+        tbr.exec768.selector,
+        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_ID,
-        commandCount, 
+        commandCount,
         PAUSE_CHAIN_ID,
         chainId,
         paused
       )
     );
 
-    (bool paused_, ) = invokeStaticTbr(
+    (bool paused_, ) = tbr.invokeStaticTbr(
       abi.encodePacked(
-        tbr.get1959.selector, 
-        DISPATCHER_PROTOCOL_VERSION0, 
+        tbr.get1959.selector,
+        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_QUERIES_ID,
-        commandCount, 
+        commandCount,
         IS_CHAIN_PAUSED_ID,
         chainId
       )
@@ -382,12 +384,12 @@ contract ConfigTest is TbrTestBase {
     uint8 commandCount = 1;
 
     vm.expectRevert(NotAuthorized.selector);
-    invokeTbr(
+    tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector, 
-        DISPATCHER_PROTOCOL_VERSION0, 
+        tbr.exec768.selector,
+        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_ID,
-        commandCount, 
+        commandCount,
         UPDATE_CANONICAL_PEER_ID,
         peerChain,
         newCanonicalPeer
@@ -395,24 +397,24 @@ contract ConfigTest is TbrTestBase {
     );
 
     vm.prank(owner);
-    invokeTbr(
+    tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector, 
-        DISPATCHER_PROTOCOL_VERSION0, 
+        tbr.exec768.selector,
+        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_ID,
-        commandCount, 
+        commandCount,
         UPDATE_CANONICAL_PEER_ID,
         peerChain,
         newCanonicalPeer
       )
     );
 
-    (bytes32 newCanonicalPeer_, ) = invokeStaticTbr(
+    (bytes32 newCanonicalPeer_, ) = tbr.invokeStaticTbr(
       abi.encodePacked(
-        tbr.get1959.selector, 
-        DISPATCHER_PROTOCOL_VERSION0, 
+        tbr.get1959.selector,
+        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_QUERIES_ID,
-        commandCount, 
+        commandCount,
         CANONICAL_PEER_ID,
         peerChain
       )
@@ -425,12 +427,12 @@ contract ConfigTest is TbrTestBase {
     uint16 chainId = 1;
     uint8 commandCount = 1;
 
-    (bool isSupported, ) = invokeStaticTbr(
+    (bool isSupported, ) = tbr.invokeStaticTbr(
       abi.encodePacked(
-        tbr.get1959.selector, 
-        DISPATCHER_PROTOCOL_VERSION0, 
+        tbr.get1959.selector,
+        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_QUERIES_ID,
-        commandCount, 
+        commandCount,
         IS_CHAIN_SUPPORTED_ID,
         chainId
       )
@@ -440,12 +442,12 @@ contract ConfigTest is TbrTestBase {
     vm.prank(owner);
     addCanonicalPeer(chainId, makeBytes32("peer"));
 
-    (isSupported, ) = invokeStaticTbr(
+    (isSupported, ) = tbr.invokeStaticTbr(
       abi.encodePacked(
-        tbr.get1959.selector, 
-        DISPATCHER_PROTOCOL_VERSION0, 
+        tbr.get1959.selector,
+        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_QUERIES_ID,
-        commandCount, 
+        commandCount,
         IS_CHAIN_SUPPORTED_ID,
         chainId
       )
@@ -456,19 +458,19 @@ contract ConfigTest is TbrTestBase {
   function testInvalidCommand() public {
     uint8 commandCount = 1;
 
-    // The first query command, so should fail because the exec 
+    // The first query command, so should fail because the exec
     // function will not be able to handle it.
     uint8 fakeCommand = 0x80;
     vm.prank(owner);
     vm.expectRevert(
       abi.encodeWithSelector(InvalidConfigCommand.selector, fakeCommand)
     );
-    invokeTbr(
+    tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector, 
-        DISPATCHER_PROTOCOL_VERSION0, 
+        tbr.exec768.selector,
+        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_ID,
-        commandCount, 
+        commandCount,
         fakeCommand
       )
     );
@@ -476,7 +478,7 @@ contract ConfigTest is TbrTestBase {
 
   function testInvalidQuery() public {
     uint8 commandCount = 1;
-    
+
     // The last exec command, so should fail because the get
     // function will not be able to handle it.
     uint8 fakeQuery = 0x79;
@@ -484,12 +486,12 @@ contract ConfigTest is TbrTestBase {
     vm.expectRevert(
       abi.encodeWithSelector(InvalidConfigQuery.selector, fakeQuery)
     );
-    invokeStaticTbr(
+    tbr.invokeStaticTbr(
       abi.encodePacked(
-        tbr.get1959.selector, 
-        DISPATCHER_PROTOCOL_VERSION0, 
+        tbr.get1959.selector,
+        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_QUERIES_ID,
-        commandCount, 
+        commandCount,
         fakeQuery
       )
     );

--- a/evm/test/ConfigTest.t.sol
+++ b/evm/test/ConfigTest.t.sol
@@ -19,8 +19,6 @@ contract ConfigTest is TbrTestBase {
     uint8 commandCount = 1;
     tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_ID,
         commandCount,
         UPDATE_CANONICAL_PEER_ID,
@@ -38,8 +36,6 @@ contract ConfigTest is TbrTestBase {
     vm.expectRevert(NotAuthorized.selector);
     tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_ID,
         commandCount,
         ADD_PEER_ID,
@@ -51,8 +47,6 @@ contract ConfigTest is TbrTestBase {
     vm.startPrank(owner);
     tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_ID,
         commandCount,
         ADD_PEER_ID,
@@ -63,8 +57,6 @@ contract ConfigTest is TbrTestBase {
 
     (bool isPeer, ) = tbr.invokeStaticTbr(
       abi.encodePacked(
-        tbr.get1959.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_QUERIES_ID,
         commandCount,
         IS_PEER_ID,
@@ -89,8 +81,6 @@ contract ConfigTest is TbrTestBase {
 
     (bool isPeer, ) = tbr.invokeStaticTbr(
       abi.encodePacked(
-        tbr.get1959.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_QUERIES_ID,
         commandCount,
         IS_PEER_ID,
@@ -103,8 +93,6 @@ contract ConfigTest is TbrTestBase {
 
     (bytes32 canonicalPeer, ) = tbr.invokeStaticTbr(
       abi.encodePacked(
-        tbr.get1959.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_QUERIES_ID,
         commandCount,
         CANONICAL_PEER_ID,
@@ -119,8 +107,6 @@ contract ConfigTest is TbrTestBase {
 
     (isPeer, ) = tbr.invokeStaticTbr(
       abi.encodePacked(
-        tbr.get1959.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_QUERIES_ID,
         commandCount,
         IS_PEER_ID,
@@ -133,8 +119,6 @@ contract ConfigTest is TbrTestBase {
 
     (canonicalPeer, ) = tbr.invokeStaticTbr(
       abi.encodePacked(
-        tbr.get1959.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_QUERIES_ID,
         commandCount,
         CANONICAL_PEER_ID,
@@ -153,8 +137,6 @@ contract ConfigTest is TbrTestBase {
     vm.expectRevert(NotAuthorized.selector);
     tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_ID,
         commandCount,
         UPDATE_MAX_GAS_DROPOFF_ID,
@@ -169,8 +151,6 @@ contract ConfigTest is TbrTestBase {
     );
     tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_ID,
         commandCount,
         UPDATE_MAX_GAS_DROPOFF_ID,
@@ -185,8 +165,6 @@ contract ConfigTest is TbrTestBase {
     vm.prank(admin);
     tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_ID,
         commandCount,
         UPDATE_MAX_GAS_DROPOFF_ID,
@@ -197,8 +175,6 @@ contract ConfigTest is TbrTestBase {
 
     (uint32 maxGasDropoff_, ) = tbr.invokeStaticTbr(
       abi.encodePacked(
-        tbr.get1959.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_QUERIES_ID,
         commandCount,
         MAX_GAS_DROPOFF_ID,
@@ -216,8 +192,6 @@ contract ConfigTest is TbrTestBase {
     vm.expectRevert(NotAuthorized.selector);
     tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_ID,
         commandCount,
         UPDATE_FEE_RECIPIENT_ID,
@@ -228,8 +202,6 @@ contract ConfigTest is TbrTestBase {
     vm.prank(admin);
     tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_ID,
         commandCount,
         UPDATE_FEE_RECIPIENT_ID,
@@ -239,8 +211,6 @@ contract ConfigTest is TbrTestBase {
 
     (address newFeeRecipient_, ) = tbr.invokeStaticTbr(
       abi.encodePacked(
-        tbr.get1959.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_QUERIES_ID,
         commandCount,
         FEE_RECIPIENT_ID
@@ -258,8 +228,6 @@ contract ConfigTest is TbrTestBase {
     vm.expectRevert(NotAuthorized.selector);
     tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_ID,
         commandCount,
         UPDATE_BASE_FEE_ID,
@@ -274,8 +242,6 @@ contract ConfigTest is TbrTestBase {
     );
     tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_ID,
         commandCount,
         UPDATE_BASE_FEE_ID,
@@ -290,8 +256,6 @@ contract ConfigTest is TbrTestBase {
     vm.prank(admin);
     tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_ID,
         commandCount,
         UPDATE_BASE_FEE_ID,
@@ -302,8 +266,6 @@ contract ConfigTest is TbrTestBase {
 
     (uint32 newRelayFee_, ) = tbr.invokeStaticTbr(
       abi.encodePacked(
-        tbr.get1959.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_QUERIES_ID,
         commandCount,
         BASE_FEE_ID,
@@ -322,8 +284,6 @@ contract ConfigTest is TbrTestBase {
     vm.expectRevert(NotAuthorized.selector);
     tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_ID,
         commandCount,
         PAUSE_CHAIN_ID,
@@ -338,8 +298,6 @@ contract ConfigTest is TbrTestBase {
     );
     tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_ID,
         commandCount,
         PAUSE_CHAIN_ID,
@@ -354,8 +312,6 @@ contract ConfigTest is TbrTestBase {
     vm.prank(admin);
     tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_ID,
         commandCount,
         PAUSE_CHAIN_ID,
@@ -366,8 +322,6 @@ contract ConfigTest is TbrTestBase {
 
     (bool paused_, ) = tbr.invokeStaticTbr(
       abi.encodePacked(
-        tbr.get1959.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_QUERIES_ID,
         commandCount,
         IS_CHAIN_PAUSED_ID,
@@ -386,8 +340,6 @@ contract ConfigTest is TbrTestBase {
     vm.expectRevert(NotAuthorized.selector);
     tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_ID,
         commandCount,
         UPDATE_CANONICAL_PEER_ID,
@@ -399,8 +351,6 @@ contract ConfigTest is TbrTestBase {
     vm.prank(owner);
     tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_ID,
         commandCount,
         UPDATE_CANONICAL_PEER_ID,
@@ -411,8 +361,6 @@ contract ConfigTest is TbrTestBase {
 
     (bytes32 newCanonicalPeer_, ) = tbr.invokeStaticTbr(
       abi.encodePacked(
-        tbr.get1959.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_QUERIES_ID,
         commandCount,
         CANONICAL_PEER_ID,
@@ -429,8 +377,6 @@ contract ConfigTest is TbrTestBase {
 
     (bool isSupported, ) = tbr.invokeStaticTbr(
       abi.encodePacked(
-        tbr.get1959.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_QUERIES_ID,
         commandCount,
         IS_CHAIN_SUPPORTED_ID,
@@ -444,8 +390,6 @@ contract ConfigTest is TbrTestBase {
 
     (isSupported, ) = tbr.invokeStaticTbr(
       abi.encodePacked(
-        tbr.get1959.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_QUERIES_ID,
         commandCount,
         IS_CHAIN_SUPPORTED_ID,
@@ -467,8 +411,6 @@ contract ConfigTest is TbrTestBase {
     );
     tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_ID,
         commandCount,
         fakeCommand
@@ -488,8 +430,6 @@ contract ConfigTest is TbrTestBase {
     );
     tbr.invokeStaticTbr(
       abi.encodePacked(
-        tbr.get1959.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_QUERIES_ID,
         commandCount,
         fakeQuery

--- a/evm/test/Dispatcher.t.sol
+++ b/evm/test/Dispatcher.t.sol
@@ -4,11 +4,13 @@ pragma solidity ^0.8.25;
 
 import { BytesParsing } from "wormhole-sdk/libraries/BytesParsing.sol";
 import { DISPATCHER_PROTOCOL_VERSION0 } from "tbr/assets/TbrIds.sol";
-import { TbrTestBase } from "./utils/TbrTestBase.sol";
+import { TbrTestBase, InvokeTbr } from "./utils/TbrTestBase.sol";
+import { Tbr } from "tbr/Tbr.sol";
 import { UnsupportedVersion, InvalidCommand } from "tbr/assets/TbrDispatcher.sol";
 
 contract DispatcherTest is TbrTestBase {
   using BytesParsing for bytes;
+  using InvokeTbr for Tbr;
 
   function testExec() public {
     uint8 wrongVersion = 1;
@@ -17,17 +19,17 @@ contract DispatcherTest is TbrTestBase {
     vm.expectRevert(
       abi.encodeWithSelector(UnsupportedVersion.selector, wrongVersion)
     );
-    invokeTbr(
+    tbr.invokeTbr(
       abi.encodePacked(tbr.exec768.selector, wrongVersion)
     );
 
-    // The first query command, so should fail because the exec 
+    // The first query command, so should fail because the exec
     // function will not be able to handle it.
     uint8 fakeCommand = 0x80;
     vm.expectRevert(
       abi.encodeWithSelector(InvalidCommand.selector, fakeCommand, expectedCommandIndex)
     );
-    invokeTbr(
+    tbr.invokeTbr(
       abi.encodePacked(tbr.exec768.selector, DISPATCHER_PROTOCOL_VERSION0, fakeCommand)
     );
   }
@@ -39,7 +41,7 @@ contract DispatcherTest is TbrTestBase {
     vm.expectRevert(
       abi.encodeWithSelector(UnsupportedVersion.selector, wrongVersion)
     );
-    invokeStaticTbr(
+    tbr.invokeStaticTbr(
       abi.encodePacked(tbr.get1959.selector, wrongVersion)
     );
 
@@ -49,7 +51,7 @@ contract DispatcherTest is TbrTestBase {
     vm.expectRevert(
       abi.encodeWithSelector(InvalidCommand.selector, fakeQuery, expextedQueryIndex)
     );
-    invokeStaticTbr(
+    tbr.invokeStaticTbr(
       abi.encodePacked(tbr.get1959.selector, DISPATCHER_PROTOCOL_VERSION0, fakeQuery)
     );
   }

--- a/evm/test/Dispatcher.t.sol
+++ b/evm/test/Dispatcher.t.sol
@@ -3,10 +3,10 @@
 pragma solidity ^0.8.25;
 
 import { BytesParsing } from "wormhole-sdk/libraries/BytesParsing.sol";
-import { DISPATCHER_PROTOCOL_VERSION0 } from "tbr/assets/TbrIds.sol";
 import { TbrTestBase, InvokeTbr } from "./utils/TbrTestBase.sol";
 import { Tbr } from "tbr/Tbr.sol";
 import { UnsupportedVersion, InvalidCommand } from "tbr/assets/TbrDispatcher.sol";
+import { reRevert } from "wormhole-sdk/Utils.sol";
 
 contract DispatcherTest is TbrTestBase {
   using BytesParsing for bytes;
@@ -19,9 +19,11 @@ contract DispatcherTest is TbrTestBase {
     vm.expectRevert(
       abi.encodeWithSelector(UnsupportedVersion.selector, wrongVersion)
     );
-    tbr.invokeTbr(
-      abi.encodePacked(tbr.exec768.selector, wrongVersion)
-    );
+    bytes memory execCall = abi.encodePacked(tbr.exec768.selector, wrongVersion);
+    (bool success, bytes memory result) = address(tbr).call(execCall);
+    if (!success) {
+      reRevert(result);
+    }
 
     // The first query command, so should fail because the exec
     // function will not be able to handle it.
@@ -30,29 +32,31 @@ contract DispatcherTest is TbrTestBase {
       abi.encodeWithSelector(InvalidCommand.selector, fakeCommand, expectedCommandIndex)
     );
     tbr.invokeTbr(
-      abi.encodePacked(tbr.exec768.selector, DISPATCHER_PROTOCOL_VERSION0, fakeCommand)
+      abi.encodePacked(fakeCommand)
     );
   }
 
   function testGet() public {
     uint8 wrongVersion = 1;
-    uint256 expextedQueryIndex = 0;
+    uint256 expectedQueryIndex = 0;
 
     vm.expectRevert(
       abi.encodeWithSelector(UnsupportedVersion.selector, wrongVersion)
     );
-    tbr.invokeStaticTbr(
-      abi.encodePacked(tbr.get1959.selector, wrongVersion)
-    );
+    bytes memory getCall = abi.encodePacked(tbr.get1959.selector, wrongVersion);
+    (bool success, bytes memory result) = address(tbr).staticcall(getCall);
+    if (!success) {
+      reRevert(result);
+    }
 
     // The last exec command, so should fail because the get
     // function will not be able to handle it.
     uint8 fakeQuery = 0x79;
     vm.expectRevert(
-      abi.encodeWithSelector(InvalidCommand.selector, fakeQuery, expextedQueryIndex)
+      abi.encodeWithSelector(InvalidCommand.selector, fakeQuery, expectedQueryIndex)
     );
     tbr.invokeStaticTbr(
-      abi.encodePacked(tbr.get1959.selector, DISPATCHER_PROTOCOL_VERSION0, fakeQuery)
+      abi.encodePacked(fakeQuery)
     );
   }
 }

--- a/evm/test/DispatcherComponents.t.sol
+++ b/evm/test/DispatcherComponents.t.sol
@@ -6,29 +6,31 @@ import { NotAuthorized } from "wormhole-sdk/components/dispatcher/AccessControl.
 import { BytesParsing } from "wormhole-sdk/libraries/BytesParsing.sol";
 import { IdempotentUpgrade } from "wormhole-sdk/proxy/ProxyBase.sol";
 import { UpgradeTester } from "./utils/UpgradeTester.sol";
-import { TbrTestBase } from "./utils/TbrTestBase.sol";
+import { TbrTestBase, InvokeTbr } from "./utils/TbrTestBase.sol";
+import { Tbr } from "tbr/Tbr.sol";
 import "wormhole-sdk/components/dispatcher/Ids.sol";
 import "tbr/assets/TbrIds.sol";
 
 contract ConfigTest is TbrTestBase {
   using BytesParsing for bytes;
+  using InvokeTbr for Tbr;
 
   function testContractUpgrade() public {
     UpgradeTester upgradeTester = new UpgradeTester();
 
-    (address implementation, ) = invokeStaticTbr(
+    (address implementation, ) = tbr.invokeStaticTbr(
       abi.encodePacked(
-        tbr.get1959.selector, 
-        DISPATCHER_PROTOCOL_VERSION0, 
+        tbr.get1959.selector,
+        DISPATCHER_PROTOCOL_VERSION0,
         IMPLEMENTATION_ID
       )
     ).asAddressMemUnchecked(0);
 
     vm.expectRevert(NotAuthorized.selector);
-    invokeTbr(
+    tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector, 
-        DISPATCHER_PROTOCOL_VERSION0, 
+        tbr.exec768.selector,
+        DISPATCHER_PROTOCOL_VERSION0,
         UPGRADE_CONTRACT_ID,
         address(upgradeTester)
       )
@@ -36,20 +38,20 @@ contract ConfigTest is TbrTestBase {
 
     vm.startPrank(admin);
     vm.expectRevert(NotAuthorized.selector);
-    invokeTbr(
+    tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector, 
-        DISPATCHER_PROTOCOL_VERSION0, 
+        tbr.exec768.selector,
+        DISPATCHER_PROTOCOL_VERSION0,
         UPGRADE_CONTRACT_ID,
         address(upgradeTester)
       )
     );
 
     vm.startPrank(owner);
-    invokeTbr(
+    tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector, 
-        DISPATCHER_PROTOCOL_VERSION0, 
+        tbr.exec768.selector,
+        DISPATCHER_PROTOCOL_VERSION0,
         UPGRADE_CONTRACT_ID,
         address(upgradeTester)
       )
@@ -60,10 +62,10 @@ contract ConfigTest is TbrTestBase {
 
     UpgradeTester(address(tbr)).upgradeTo(implementation, new bytes(0));
 
-    (address restoredImplementation, ) = invokeStaticTbr(
+    (address restoredImplementation, ) = tbr.invokeStaticTbr(
       abi.encodePacked(
-        tbr.get1959.selector, 
-        DISPATCHER_PROTOCOL_VERSION0, 
+        tbr.get1959.selector,
+        DISPATCHER_PROTOCOL_VERSION0,
         IMPLEMENTATION_ID
       )
     ).asAddressMemUnchecked(0);
@@ -74,36 +76,36 @@ contract ConfigTest is TbrTestBase {
     uint8 commandCount = 1;
 
     vm.expectRevert(NotAuthorized.selector);
-    invokeTbr(
+    tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector, 
+        tbr.exec768.selector,
         DISPATCHER_PROTOCOL_VERSION0,
         ACCESS_CONTROL_ID,
-        commandCount, 
+        commandCount,
         PROPOSE_OWNERSHIP_TRANSFER_ID,
         newOwner
       )
     );
 
     vm.prank(owner);
-    invokeTbr(
+    tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector, 
-        DISPATCHER_PROTOCOL_VERSION0, 
+        tbr.exec768.selector,
+        DISPATCHER_PROTOCOL_VERSION0,
         ACCESS_CONTROL_ID,
-        commandCount, 
+        commandCount,
         PROPOSE_OWNERSHIP_TRANSFER_ID,
         newOwner
       )
     );
-    
+
     commandCount = 2;
-    bytes memory getRes = invokeStaticTbr(
+    bytes memory getRes = tbr.invokeStaticTbr(
       abi.encodePacked(
-        tbr.get1959.selector, 
-        DISPATCHER_PROTOCOL_VERSION0, 
+        tbr.get1959.selector,
+        DISPATCHER_PROTOCOL_VERSION0,
         ACCESS_CONTROL_QUERIES_ID,
-        commandCount, 
+        commandCount,
         OWNER_ID,
         PENDING_OWNER_ID
       )
@@ -115,30 +117,30 @@ contract ConfigTest is TbrTestBase {
     assertEq(pendingOwner_, newOwner);
 
     vm.expectRevert(NotAuthorized.selector);
-    invokeTbr(
+    tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector, 
-        DISPATCHER_PROTOCOL_VERSION0, 
+        tbr.exec768.selector,
+        DISPATCHER_PROTOCOL_VERSION0,
         ACQUIRE_OWNERSHIP_ID
       )
     );
 
     vm.prank(newOwner);
-    invokeTbr(
+    tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector, 
-        DISPATCHER_PROTOCOL_VERSION0, 
+        tbr.exec768.selector,
+        DISPATCHER_PROTOCOL_VERSION0,
         ACQUIRE_OWNERSHIP_ID
       )
     );
 
     commandCount = 2;
-    getRes = invokeStaticTbr(
+    getRes = tbr.invokeStaticTbr(
       abi.encodePacked(
-        tbr.get1959.selector, 
-        DISPATCHER_PROTOCOL_VERSION0, 
+        tbr.get1959.selector,
+        DISPATCHER_PROTOCOL_VERSION0,
         ACCESS_CONTROL_QUERIES_ID,
-        commandCount, 
+        commandCount,
         OWNER_ID,
         PENDING_OWNER_ID
       )
@@ -160,10 +162,10 @@ contract ConfigTest is TbrTestBase {
     assertEq(usdt.balanceOf(address(tbr)), usdtAmount);
     assertEq(address(tbr).balance, ethAmount);
     vm.prank(owner);
-    invokeTbr(
+    tbr.invokeTbr(
       abi.encodePacked(
-      tbr.exec768.selector, 
-      DISPATCHER_PROTOCOL_VERSION0, 
+      tbr.exec768.selector,
+      DISPATCHER_PROTOCOL_VERSION0,
       SWEEP_TOKENS_ID, address(usdt), usdtAmount,
       SWEEP_TOKENS_ID, address(0), ethAmount
       )

--- a/evm/test/DispatcherComponents.t.sol
+++ b/evm/test/DispatcherComponents.t.sol
@@ -20,8 +20,6 @@ contract ConfigTest is TbrTestBase {
 
     (address implementation, ) = tbr.invokeStaticTbr(
       abi.encodePacked(
-        tbr.get1959.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         IMPLEMENTATION_ID
       )
     ).asAddressMemUnchecked(0);
@@ -29,8 +27,6 @@ contract ConfigTest is TbrTestBase {
     vm.expectRevert(NotAuthorized.selector);
     tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         UPGRADE_CONTRACT_ID,
         address(upgradeTester)
       )
@@ -40,8 +36,6 @@ contract ConfigTest is TbrTestBase {
     vm.expectRevert(NotAuthorized.selector);
     tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         UPGRADE_CONTRACT_ID,
         address(upgradeTester)
       )
@@ -50,8 +44,6 @@ contract ConfigTest is TbrTestBase {
     vm.startPrank(owner);
     tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         UPGRADE_CONTRACT_ID,
         address(upgradeTester)
       )
@@ -64,8 +56,6 @@ contract ConfigTest is TbrTestBase {
 
     (address restoredImplementation, ) = tbr.invokeStaticTbr(
       abi.encodePacked(
-        tbr.get1959.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         IMPLEMENTATION_ID
       )
     ).asAddressMemUnchecked(0);
@@ -78,8 +68,6 @@ contract ConfigTest is TbrTestBase {
     vm.expectRevert(NotAuthorized.selector);
     tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         ACCESS_CONTROL_ID,
         commandCount,
         PROPOSE_OWNERSHIP_TRANSFER_ID,
@@ -90,8 +78,6 @@ contract ConfigTest is TbrTestBase {
     vm.prank(owner);
     tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         ACCESS_CONTROL_ID,
         commandCount,
         PROPOSE_OWNERSHIP_TRANSFER_ID,
@@ -102,8 +88,6 @@ contract ConfigTest is TbrTestBase {
     commandCount = 2;
     bytes memory getRes = tbr.invokeStaticTbr(
       abi.encodePacked(
-        tbr.get1959.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         ACCESS_CONTROL_QUERIES_ID,
         commandCount,
         OWNER_ID,
@@ -119,8 +103,6 @@ contract ConfigTest is TbrTestBase {
     vm.expectRevert(NotAuthorized.selector);
     tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         ACQUIRE_OWNERSHIP_ID
       )
     );
@@ -128,8 +110,6 @@ contract ConfigTest is TbrTestBase {
     vm.prank(newOwner);
     tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         ACQUIRE_OWNERSHIP_ID
       )
     );
@@ -137,8 +117,6 @@ contract ConfigTest is TbrTestBase {
     commandCount = 2;
     getRes = tbr.invokeStaticTbr(
       abi.encodePacked(
-        tbr.get1959.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         ACCESS_CONTROL_QUERIES_ID,
         commandCount,
         OWNER_ID,
@@ -164,8 +142,6 @@ contract ConfigTest is TbrTestBase {
     vm.prank(owner);
     tbr.invokeTbr(
       abi.encodePacked(
-      tbr.exec768.selector,
-      DISPATCHER_PROTOCOL_VERSION0,
       SWEEP_TOKENS_ID, address(usdt), usdtAmount,
       SWEEP_TOKENS_ID, address(0), ethAmount
       )

--- a/evm/test/OracleIntegration.t.sol
+++ b/evm/test/OracleIntegration.t.sol
@@ -9,13 +9,13 @@ import { TbrExposer } from "./utils/TbrExposer.sol";
 
 contract OracleIntegrationTest is TbrTestBase {
   using BytesParsing for bytes;
-  
+
   uint32  RELAY_FEE_AMOUNT = 1000;
 
   function _setUp1() internal override {
     vm.mockCall(
-      address(wormholeCore), 
-      abi.encodeWithSelector(wormholeCore.chainId.selector), 
+      address(wormholeCore),
+      abi.encodeWithSelector(wormholeCore.chainId.selector),
       abi.encode(EVM_CHAIN_ID)
     );
 
@@ -27,7 +27,7 @@ contract OracleIntegrationTest is TbrTestBase {
       gasErc20TokenizationIsExplicit
     );
   }
-  
+
   function testQuoteRelay_evmTransactionQuote() public {
     uint32 gasDropoff = 1000;
     uint16 chainId = EVM_CHAIN_ID;
@@ -35,7 +35,7 @@ contract OracleIntegrationTest is TbrTestBase {
 
     uint fakeWormholeFee = 100;
     vm.mockCall(
-      address(wormholeCore), 
+      address(wormholeCore),
       abi.encodeWithSelector(
         wormholeCore.messageFee.selector
       ),
@@ -45,7 +45,7 @@ contract OracleIntegrationTest is TbrTestBase {
     (uint256 quote, uint256 wormholeFee) = tbrExposer.exposedQuoteRelay(chainId, gasDropoff, RELAY_FEE_AMOUNT);
     assertEq(quote, expectedQuote);
     assertEq(fakeWormholeFee, wormholeFee);
-  } 
+  }
 
   function testQuoteRelay_evmTransactionWithTxSizeQuote() public {
     uint32 gasDropoff = 1000;
@@ -54,7 +54,7 @@ contract OracleIntegrationTest is TbrTestBase {
 
     uint fakeWormholeFee = 100;
     vm.mockCall(
-      address(wormholeCore), 
+      address(wormholeCore),
       abi.encodeWithSelector(
         wormholeCore.messageFee.selector
       ),
@@ -64,7 +64,7 @@ contract OracleIntegrationTest is TbrTestBase {
     (uint256 quote, uint256 wormholeFee) = tbrExposer.exposedQuoteRelay(chainId, gasDropoff, RELAY_FEE_AMOUNT);
     assertEq(quote, expectedQuote);
     assertEq(fakeWormholeFee, wormholeFee);
-  } 
+  }
 
   function testQuoteRelay_solanaTransactionQuote() public {
     uint32 gasDropoff = 1000;
@@ -73,7 +73,7 @@ contract OracleIntegrationTest is TbrTestBase {
 
     uint fakeWormholeFee = 100;
     vm.mockCall(
-      address(wormholeCore), 
+      address(wormholeCore),
       abi.encodeWithSelector(
         wormholeCore.messageFee.selector
       ),
@@ -83,5 +83,5 @@ contract OracleIntegrationTest is TbrTestBase {
     (uint256 quote, uint256 wormholeFee) = tbrExposer.exposedQuoteRelay(chainId, gasDropoff, RELAY_FEE_AMOUNT);
     assertEq(quote, expectedQuote);
     assertEq(fakeWormholeFee, wormholeFee);
-  } 
+  }
 }

--- a/evm/test/User.t.sol
+++ b/evm/test/User.t.sol
@@ -15,7 +15,8 @@ import { IPriceOracle } from "price-oracle/IPriceOracle.sol";
 import { toUniversalAddress } from "wormhole-sdk/Utils.sol";
 import { CHAIN_ID_ETHEREUM } from "wormhole-sdk/constants/Chains.sol";
 
-import { TbrTestBase } from "./utils/TbrTestBase.sol";
+import { TbrTestBase, InvokeTbr } from "./utils/TbrTestBase.sol";
+import { Tbr } from "tbr/Tbr.sol";
 import { craftTbrV3Vaa, deNormalizeAmount, discardInsignificantBits, ERC20Mock, makeBytes32 } from "./utils/utils.sol";
 
 // USDC in Ethereum mainnet
@@ -23,6 +24,7 @@ address constant usdcAddress = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
 
 contract UserTest is TbrTestBase {
   using BytesParsing for bytes;
+  using InvokeTbr for Tbr;
 
   bytes32 SOLANA_CANONICAL_PEER  = makeBytes32("SOLANA_CANONICAL_PEER");
   bytes32 EVM_CANONICAL_PEER     = makeBytes32("EVM_CANONICAL_PEER");
@@ -38,7 +40,7 @@ contract UserTest is TbrTestBase {
     uint8 commandCount = 1;
 
     vm.prank(owner);
-    invokeTbr(
+    tbr.invokeTbr(
       abi.encodePacked(
         tbr.exec768.selector,
         DISPATCHER_PROTOCOL_VERSION0,
@@ -163,7 +165,7 @@ contract UserTest is TbrTestBase {
     vm.expectEmit(address(tbr));
     emit TransferRequested(address(this), sequence, gasDropoff, feeQuote);
 
-    invokeTbr(
+    tbr.invokeTbr(
       abi.encodePacked(
         tbr.exec768.selector,
         DISPATCHER_PROTOCOL_VERSION0,
@@ -251,7 +253,7 @@ contract UserTest is TbrTestBase {
     );
 
     vm.expectRevert("SafeERC20: low-level call failed");
-    invokeTbr(
+    tbr.invokeTbr(
       abi.encodePacked(
         tbr.exec768.selector,
         DISPATCHER_PROTOCOL_VERSION0,
@@ -330,7 +332,7 @@ contract UserTest is TbrTestBase {
     vm.expectEmit(address(tbr));
     emit TransferRequested(address(this), sequence, gasDropoff, feeQuote);
 
-    invokeTbr(
+    tbr.invokeTbr(
       abi.encodePacked(
         tbr.exec768.selector,
         DISPATCHER_PROTOCOL_VERSION0,
@@ -374,7 +376,7 @@ contract UserTest is TbrTestBase {
     vm.expectEmit(address(tbr));
     emit TransferRequested(address(this), sequence, gasDropoff, feeQuote);
 
-    invokeTbr(
+    tbr.invokeTbr(
       abi.encodePacked(
         tbr.exec768.selector,
         DISPATCHER_PROTOCOL_VERSION0,
@@ -436,7 +438,7 @@ contract UserTest is TbrTestBase {
       abi.encodeWithSelector(FeesInsufficient.selector, unallocatedBalance, commandIndex)
     );
 
-    invokeTbr(
+    tbr.invokeTbr(
       abi.encodePacked(
         tbr.exec768.selector,
         DISPATCHER_PROTOCOL_VERSION0,
@@ -516,7 +518,7 @@ contract UserTest is TbrTestBase {
     vm.expectEmit(address(tbr));
     emit TransferRequested(address(this), sequence, gasDropoff, feeQuote);
 
-    invokeTbr(
+    tbr.invokeTbr(
       abi.encodePacked(
         tbr.exec768.selector,
         DISPATCHER_PROTOCOL_VERSION0,
@@ -593,7 +595,7 @@ contract UserTest is TbrTestBase {
     );
 
     vm.expectRevert("SafeERC20: low-level call failed");
-    invokeTbr(
+    tbr.invokeTbr(
       abi.encodePacked(
         tbr.exec768.selector,
         DISPATCHER_PROTOCOL_VERSION0,
@@ -637,7 +639,7 @@ contract UserTest is TbrTestBase {
       abi.encodeWithSelector(FeesInsufficient.selector, unallocatedBalance, commandIndex)
     );
 
-    invokeTbr(
+    tbr.invokeTbr(
       abi.encodePacked(
         tbr.exec768.selector,
         DISPATCHER_PROTOCOL_VERSION0,
@@ -1121,7 +1123,7 @@ contract UserTest is TbrTestBase {
       abi.encode(abi.encodePacked(uint256(feeQuote)))
     );
 
-    bytes memory response = invokeStaticTbr(
+    bytes memory response = tbr.invokeStaticTbr(
       abi.encodePacked(
         tbr.get1959.selector,
         DISPATCHER_PROTOCOL_VERSION0,
@@ -1151,7 +1153,7 @@ contract UserTest is TbrTestBase {
       abi.encode(abi.encodePacked(uint256(feeQuote)))
     );
 
-    bytes memory response = invokeStaticTbr(
+    bytes memory response = tbr.invokeStaticTbr(
       abi.encodePacked(
         tbr.get1959.selector,
         DISPATCHER_PROTOCOL_VERSION0,
@@ -1196,7 +1198,7 @@ contract UserTest is TbrTestBase {
       abi.encode(uint256(fakeWormholeFee))
     );
 
-    bytes memory response = invokeStaticTbr(
+    bytes memory response = tbr.invokeStaticTbr(
       abi.encodePacked(
         tbr.get1959.selector,
         DISPATCHER_PROTOCOL_VERSION0,
@@ -1226,7 +1228,7 @@ contract UserTest is TbrTestBase {
         commandIndex
       )
     );
-    invokeStaticTbr(
+    tbr.invokeStaticTbr(
       abi.encodePacked(
         tbr.get1959.selector,
         DISPATCHER_PROTOCOL_VERSION0,
@@ -1238,7 +1240,7 @@ contract UserTest is TbrTestBase {
   }
 
   function testBaseRelayingConfig() public view {
-    bytes memory response = invokeStaticTbr(
+    bytes memory response = tbr.invokeStaticTbr(
       abi.encodePacked(
         tbr.get1959.selector,
         DISPATCHER_PROTOCOL_VERSION0,
@@ -1263,7 +1265,7 @@ contract UserTest is TbrTestBase {
     assertEq(chainIsPaused, false);
     assertEq(response.length, offset);
 
-    response = invokeStaticTbr(
+    response = tbr.invokeStaticTbr(
       abi.encodePacked(
         tbr.get1959.selector,
         DISPATCHER_PROTOCOL_VERSION0,
@@ -1341,7 +1343,7 @@ contract UserTest is TbrTestBase {
     vm.expectEmit(address(tokenToTransfer));
     emit IWETH.Withdrawal(address(tbr), denormalizedAmount);
 
-    invokeTbr(
+    tbr.invokeTbr(
       abi.encodePacked(
         tbr.exec768.selector,
         DISPATCHER_PROTOCOL_VERSION0,
@@ -1414,7 +1416,7 @@ contract UserTest is TbrTestBase {
     vm.expectEmit(tokenToTransfer);
     emit IERC20.Transfer(address(tbr), recipient, denormalizedAmount);
 
-    invokeTbr(
+    tbr.invokeTbr(
       abi.encodePacked(
         tbr.exec768.selector,
         DISPATCHER_PROTOCOL_VERSION0,
@@ -1472,7 +1474,7 @@ contract UserTest is TbrTestBase {
       )
     );
 
-    invokeTbr(
+    tbr.invokeTbr(
       abi.encodePacked(
         tbr.exec768.selector,
         DISPATCHER_PROTOCOL_VERSION0,
@@ -1523,7 +1525,7 @@ contract UserTest is TbrTestBase {
       )
     );
 
-    invokeTbr(
+    tbr.invokeTbr(
       abi.encodePacked(
         tbr.exec768.selector,
         DISPATCHER_PROTOCOL_VERSION0,
@@ -1577,7 +1579,7 @@ contract UserTest is TbrTestBase {
       )
     );
 
-    invokeTbr(
+    tbr.invokeTbr(
       abi.encodePacked(
         tbr.exec768.selector,
         DISPATCHER_PROTOCOL_VERSION0,
@@ -1637,7 +1639,7 @@ function testCompleteTransfer_GasDropoffNotNecessaryInRecipientCall(
     vm.expectEmit(tokenToTransfer);
     emit IERC20.Transfer(address(tbr), recipient, denormalizedAmount);
 
-    invokeTbr(
+    tbr.invokeTbr(
       abi.encodePacked(
         tbr.exec768.selector,
         DISPATCHER_PROTOCOL_VERSION0,
@@ -1713,7 +1715,7 @@ function testCompleteTransfer_GasDropoffNotNecessaryInRecipientCall(
       errorId
     ));
 
-    bytes memory result = expectRevertInvokeTbr(
+    bytes memory result = tbr.expectRevertInvokeTbr(
       abi.encodePacked(
         tbr.exec768.selector,
         DISPATCHER_PROTOCOL_VERSION0,

--- a/evm/test/User.t.sol
+++ b/evm/test/User.t.sol
@@ -42,8 +42,6 @@ contract UserTest is TbrTestBase {
     vm.prank(owner);
     tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         CONFIG_ID,
         commandCount,
         command
@@ -167,8 +165,6 @@ contract UserTest is TbrTestBase {
 
     tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         APPROVE_TOKEN_ID,
         usdt,
         TRANSFER_TOKEN_WITH_RELAY_ID,
@@ -255,8 +251,6 @@ contract UserTest is TbrTestBase {
     vm.expectRevert("SafeERC20: low-level call failed");
     tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         TRANSFER_TOKEN_WITH_RELAY_ID,
         targetChain,
         recipient,
@@ -334,8 +328,6 @@ contract UserTest is TbrTestBase {
 
     tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         APPROVE_TOKEN_ID,
         token,
         TRANSFER_TOKEN_WITH_RELAY_ID,
@@ -378,8 +370,6 @@ contract UserTest is TbrTestBase {
 
     tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         TRANSFER_TOKEN_WITH_RELAY_ID,
         targetChain,
         recipient,
@@ -440,8 +430,6 @@ contract UserTest is TbrTestBase {
 
     tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         TRANSFER_TOKEN_WITH_RELAY_ID,
         targetChain,
         recipient,
@@ -520,8 +508,6 @@ contract UserTest is TbrTestBase {
 
     tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         APPROVE_TOKEN_ID,
         gasToken,
         TRANSFER_GAS_TOKEN_WITH_RELAY_ID,
@@ -597,8 +583,6 @@ contract UserTest is TbrTestBase {
     vm.expectRevert("SafeERC20: low-level call failed");
     tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         TRANSFER_GAS_TOKEN_WITH_RELAY_ID,
         targetChain,
         recipient,
@@ -641,8 +625,6 @@ contract UserTest is TbrTestBase {
 
     tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         TRANSFER_GAS_TOKEN_WITH_RELAY_ID,
         targetChain,
         recipient,
@@ -1125,8 +1107,6 @@ contract UserTest is TbrTestBase {
 
     bytes memory response = tbr.invokeStaticTbr(
       abi.encodePacked(
-        tbr.get1959.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         RELAY_FEE_ID,
         SOLANA_CHAIN_ID,
         gasDropoff
@@ -1155,8 +1135,6 @@ contract UserTest is TbrTestBase {
 
     bytes memory response = tbr.invokeStaticTbr(
       abi.encodePacked(
-        tbr.get1959.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         RELAY_FEE_ID,
         SOLANA_CHAIN_ID,
         gasDropoff,
@@ -1200,8 +1178,6 @@ contract UserTest is TbrTestBase {
 
     bytes memory response = tbr.invokeStaticTbr(
       abi.encodePacked(
-        tbr.get1959.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         RELAY_FEE_ID,
         SOLANA_CHAIN_ID,
         gasDropoff
@@ -1230,8 +1206,6 @@ contract UserTest is TbrTestBase {
     );
     tbr.invokeStaticTbr(
       abi.encodePacked(
-        tbr.get1959.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         RELAY_FEE_ID,
         SOLANA_CHAIN_ID,
         gasDropoff
@@ -1242,8 +1216,6 @@ contract UserTest is TbrTestBase {
   function testBaseRelayingConfig() public view {
     bytes memory response = tbr.invokeStaticTbr(
       abi.encodePacked(
-        tbr.get1959.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         BASE_RELAYING_CONFIG_ID,
         SOLANA_CHAIN_ID
       )
@@ -1267,8 +1239,6 @@ contract UserTest is TbrTestBase {
 
     response = tbr.invokeStaticTbr(
       abi.encodePacked(
-        tbr.get1959.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         BASE_RELAYING_CONFIG_ID,
         EVM_CHAIN_ID
       )
@@ -1308,7 +1278,7 @@ contract UserTest is TbrTestBase {
     bool unwrapIntent = true;
 
     uint16 tokenChain = CHAIN_ID_ETHEREUM;
-    bytes32 tokenAddress = WETH_CANONICAL_ADDRESS;
+    bytes32 tokenAddress = toUniversalAddress(WETH_CANONICAL_ADDRESS);
 
     deal(address(this), unallocatedBalance);
 
@@ -1345,8 +1315,6 @@ contract UserTest is TbrTestBase {
 
     tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         COMPLETE_TRANSFER_ID,
         encodedVaa
       ),
@@ -1418,8 +1386,6 @@ contract UserTest is TbrTestBase {
 
     tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         COMPLETE_TRANSFER_ID,
         encodedVaa
       ),
@@ -1476,8 +1442,6 @@ contract UserTest is TbrTestBase {
 
     tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         COMPLETE_TRANSFER_ID,
         encodedVaa
       )
@@ -1527,8 +1491,6 @@ contract UserTest is TbrTestBase {
 
     tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         COMPLETE_TRANSFER_ID,
         encodedVaa
       )
@@ -1581,8 +1543,6 @@ contract UserTest is TbrTestBase {
 
     tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         COMPLETE_TRANSFER_ID,
         encodedVaa
       ),
@@ -1641,8 +1601,6 @@ function testCompleteTransfer_GasDropoffNotNecessaryInRecipientCall(
 
     tbr.invokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         COMPLETE_TRANSFER_ID,
         encodedVaa
       ),
@@ -1677,7 +1635,7 @@ function testCompleteTransfer_GasDropoffNotNecessaryInRecipientCall(
     bool unwrapIntent = true;
 
     uint16 tokenChain = CHAIN_ID_ETHEREUM;
-    bytes32 tokenAddress = WETH_CANONICAL_ADDRESS;
+    bytes32 tokenAddress = toUniversalAddress(WETH_CANONICAL_ADDRESS);
 
     deal(address(this), unallocatedBalance);
 
@@ -1717,8 +1675,6 @@ function testCompleteTransfer_GasDropoffNotNecessaryInRecipientCall(
 
     bytes memory result = tbr.expectRevertInvokeTbr(
       abi.encodePacked(
-        tbr.exec768.selector,
-        DISPATCHER_PROTOCOL_VERSION0,
         COMPLETE_TRANSFER_ID,
         encodedVaa
       ),

--- a/evm/test/User.t.sol
+++ b/evm/test/User.t.sol
@@ -84,6 +84,18 @@ contract UserTest is TbrTestBase {
     );
   }
 
+  function testGasTokenAllowance() public view {
+    bytes memory result = tbr.invokeStaticTbr(
+      abi.encodePacked(
+        GAS_TOKEN_ALLOWANCE_TOKEN_BRIDGE_ID
+      )
+    );
+
+    (uint256 allowance, ) = result.asUint256MemUnchecked(0);
+    assertEq(allowance, 0);
+    assertEq(result.length, 32);
+  }
+
   function testTransferTokenWithRelaySimple(
     uint256 tokenAmount,
     uint32 gasDropoff,

--- a/evm/test/utils/TbrExposer.sol
+++ b/evm/test/utils/TbrExposer.sol
@@ -57,7 +57,7 @@ contract TbrExposer is Tbr {
   function exposedSetPause(uint16 chainId, bool paused) public {
     _setPause(chainId, paused);
   }
-  
+
   function exposedIsPaused(uint16 targetChain) public view returns (bool) {
     return _isPaused(targetChain);
   }
@@ -94,7 +94,7 @@ contract TbrExposer is Tbr {
   }
 
   function exposed_parseSharedParams(
-    bytes calldata data, 
+    bytes calldata data,
     uint offset
   ) public pure returns (
     uint16 targetChain,

--- a/evm/test/utils/TbrTestBase.sol
+++ b/evm/test/utils/TbrTestBase.sol
@@ -17,6 +17,7 @@ import { IPriceOracle } from "price-oracle/IPriceOracle.sol";
 import { PriceOracle } from "price-oracle/PriceOracle.sol";
 import { IPermit2 } from "permit2/IPermit2.sol";
 import { Tbr } from "tbr/Tbr.sol";
+import { DISPATCHER_PROTOCOL_VERSION0 } from "tbr/assets/TbrIds.sol";
 import { ITokenBridge } from "wormhole-sdk/interfaces/ITokenBridge.sol";
 import { IWormhole } from "wormhole-sdk/interfaces/IWormhole.sol";
 import { IERC20Metadata } from "wormhole-sdk/interfaces/token/IERC20Metadata.sol";
@@ -36,10 +37,10 @@ contract TbrTestBase is Test {
   uint16  EVM_CHAIN_ID    = 3;
 
   // Arbitrum data
-  uint16  EVM_L2_CHAIN_ID = 23;
-  address EVM_L2_TOKEN_WETH_TOKEN = 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1;
+  uint16  EVM_L2_CHAIN_ID             = 23;
+  address EVM_L2_TOKEN_WETH_TOKEN     = 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1;
   address EVM_L2_TOKEN_BRIDGE_ADDRESS = 0x0b2402144Bb366A632D14B83F244D2e0e21bD39c;
-  bytes32 WETH_CANONICAL_ADDRESS = 0x000000000000000000000000C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
+  address WETH_CANONICAL_ADDRESS      = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
 
   address      immutable owner;
   address      immutable admin;
@@ -179,8 +180,10 @@ library InvokeTbr {
   using BytesParsing for bytes;
   error TbrInvokeDidNotFail(bytes data, uint256 value);
 
-  function invokeStaticTbr(Tbr tbr, bytes memory encoded) view internal returns (bytes memory data) {
-    (bool success, bytes memory result) = address(tbr).staticcall(encoded);
+  function invokeStaticTbr(Tbr tbr, bytes memory messages) view internal returns (bytes memory data) {
+    bytes memory getCall = abi.encodePacked(tbr.get1959.selector, DISPATCHER_PROTOCOL_VERSION0, messages);
+
+    (bool success, bytes memory result) = address(tbr).staticcall(getCall);
     if (!success) {
       reRevert(result);
     }
@@ -188,12 +191,18 @@ library InvokeTbr {
     (data,) = result.sliceMemUnchecked(64, length);
   }
 
-  function invokeTbr(Tbr tbr, bytes memory encoded) internal returns (bytes memory data) {
-    return invokeTbr(tbr, encoded, 0);
+  function invokeTbr(Tbr tbr, bytes memory messages) internal returns (bytes memory data) {
+    return invokeTbr(tbr, messages, 0);
   }
 
-  function invokeTbr(Tbr tbr, bytes memory encoded, uint value) internal returns (bytes memory data) {
-    (bool success, bytes memory result) = address(tbr).call{value: value}(encoded);
+  function invokeTbrImplementation(Tbr tbr, bytes memory messages, uint value) internal returns (bool, bytes memory, bytes memory) {
+    bytes memory execCall = abi.encodePacked(tbr.exec768.selector, DISPATCHER_PROTOCOL_VERSION0, messages);
+    (bool success, bytes memory result) = address(tbr).call{value: value}(execCall);
+    return (success, result, execCall);
+  }
+
+  function invokeTbr(Tbr tbr, bytes memory messages, uint value) internal returns (bytes memory data) {
+    (bool success, bytes memory result, ) = invokeTbrImplementation(tbr, messages, value);
     if (!success) {
       reRevert(result);
     }
@@ -201,10 +210,10 @@ library InvokeTbr {
     (data,) = result.sliceMemUnchecked(64, length);
   }
 
-  function expectRevertInvokeTbr(Tbr tbr, bytes memory encoded, uint value) internal returns (bytes memory) {
-    (bool success, bytes memory result) = address(tbr).call{value: value}(encoded);
+  function expectRevertInvokeTbr(Tbr tbr, bytes memory messages, uint value) internal returns (bytes memory) {
+    (bool success, bytes memory result, bytes memory execCall) = invokeTbrImplementation(tbr, messages, value);
     if (success) {
-      revert TbrInvokeDidNotFail(encoded, value);
+      revert TbrInvokeDidNotFail(execCall, value);
     }
     return result;
   }

--- a/evm/test/utils/utils.sol
+++ b/evm/test/utils/utils.sol
@@ -59,7 +59,7 @@ function craftTbrV3Vaa(
 ) returns (bytes memory, uint64) {
   uint8 TOKEN_BRIDGE_PAYLOAD_ID = 3;
   bytes32 universalRecipient = toUniversalAddress(recipient);
-  
+
   bytes memory tokenBridgePayload = abi.encodePacked(
     TOKEN_BRIDGE_PAYLOAD_ID,
     amount,

--- a/sdk/evm/tbrv3/contract.ts
+++ b/sdk/evm/tbrv3/contract.ts
@@ -44,6 +44,8 @@ import {
   peerAddressItem,
   GasTokenReturn,
   gasTokenReturnLayout,
+  gasTokenAllowanceTokenBridgeReturnLayout,
+  GasTokenAllowanceTokenBridgeReturn,
 } from "./layouts.js";
 import {
   AccessControlQuery,
@@ -74,7 +76,7 @@ export interface RelayingFeeInput {
    * Token addresses involved in the transfers.
    * Must be hex encoded and '0x' prefixed.
    */
-  readonly tokens: RoArray<EvmAddress>;
+  readonly tokens: RoArray<EvmAddress | "GasToken">;
   /**
    * Transfer parameters.
    * There should be one of these per transfer request.
@@ -144,46 +146,23 @@ export class Tbrv3 {
     provider: ConnectionPrimitives,
     network: T,
     chain: EvmChainsForNetwork<T>,
-    gasToken?: EvmAddress,
   ) {
     // TODO: remove the need for these casts with an adequate helper from the SDK when there is one.
     const address = tbrV3Contracts(network, chain as any) as string;
     const evmAddress = new EvmAddress(address);
-    return this.connectUnknown(provider, network, chain, evmAddress, gasToken);
+    return this.connectUnknown(provider, evmAddress);
   }
 
   static connectUnknown(
     provider: ConnectionPrimitives,
-    network: NetworkMain,
-    chain: Chain,
     address: EvmAddress,
-    gasToken?: EvmAddress,
   ) {
-    let defaultGasToken;
-    try {
-      ([,{address: defaultGasToken}] = resolveWrappedToken(network, chain, "native"));
-    } catch {}
-
-    if (gasToken === undefined) {
-      if (chain === "Celo") {
-        defaultGasToken = getCanonicalToken(network, chain, "CELO")?.address;
-      }
-
-      if (defaultGasToken === undefined) {
-        throw new Error(`Gas token address needs to be provided for network ${network} and chain ${chain}`);
-      }
-      gasToken = new EvmAddress(defaultGasToken);
-    } else if (defaultGasToken !== undefined && !gasToken.equals(new EvmAddress(defaultGasToken))) {
-      throw new Error(`Unexpected gas token address ${gasToken} for network ${network} and chain ${chain}`);
-    }
-
-    return new Tbrv3(provider, address, gasToken);
+    return new Tbrv3(provider, address);
   }
 
   constructor(
     public readonly provider: ConnectionPrimitives,
     public readonly address: EvmAddress,
-    private readonly gasToken: EvmAddress,
   ) {}
 
   execTx<const C extends RoArray<RootCommand>>(value: bigint, commands: C): PartialTx {
@@ -258,6 +237,8 @@ export class Tbrv3 {
         deserializeResult(query, allowanceTokenBridgeReturnLayout);
       else if (query.query === "GasToken")
         deserializeResult(query, gasTokenReturnLayout);
+      else if (query.query === "GasTokenAllowanceTokenBridge")
+        deserializeResult(query, gasTokenAllowanceTokenBridgeReturnLayout);
       else if (query.query === "AccessControlQueries")
         for (const acquery of query.queries)
           if (acquery.query === "IsAdmin")
@@ -302,7 +283,7 @@ export class Tbrv3 {
 
       requiredAllowances[
         (transfer.args.method === "TransferGasTokenWithRelay")
-        ? this.gasToken.toString()
+        ? "GasToken"
         : transfer.args.inputToken.toString()
       ] += transfer.args.inputAmountInAtomic;
 
@@ -382,10 +363,16 @@ export class Tbrv3 {
       gasDropoff: arg.gasDropoff,
     }) as const satisfies RootQuery);
 
-    const allowanceQueries = [...new Set(tokens).values()].map(token => ({
-      query: "AllowanceTokenBridge",
-      inputToken: token,
-    }) as const satisfies RootQuery);
+    const allowanceQueries = [...new Set(tokens).values()].map(token => (
+      token !== "GasToken"
+      ? {
+        query: "AllowanceTokenBridge",
+        inputToken: token,
+      } as const satisfies RootQuery
+      : {
+        query: "GasTokenAllowanceTokenBridge"
+      } as const satisfies RootQuery
+    ));
 
     const queryResults = await this.query([...relayFeeQueries, ...allowanceQueries]);
 
@@ -395,6 +382,8 @@ export class Tbrv3 {
         const {result, ...args} = qRes;
         ret.feeEstimations.push({...result, ...args});
       }
+      else if (qRes.query === "GasTokenAllowanceTokenBridge")
+        ret.allowances["GasToken"] = qRes.result;
       else
         ret.allowances[qRes.inputToken.toString()] = qRes.result;
 
@@ -490,6 +479,8 @@ type RootQueryToResults<C extends RootQuery> =
   ? ArgsResult<C, AllowanceTokenBridgeReturn>
   : C extends { query: "GasToken" }
   ? ArgsResult<C, GasTokenReturn>
+  : C extends { query: "GasTokenAllowanceTokenBridge" }
+  ? ArgsResult<C, GasTokenAllowanceTokenBridgeReturn>
   : C extends { query: "AccessControlQueries" }
   ? AccessControlQueryResults<C["queries"]>
   : C extends { query: "Implementation" }

--- a/sdk/evm/tbrv3/contract.ts
+++ b/sdk/evm/tbrv3/contract.ts
@@ -42,6 +42,8 @@ import {
   allowanceTokenBridgeReturnLayout,
   execParamsLayout,
   peerAddressItem,
+  GasTokenReturn,
+  gasTokenReturnLayout,
 } from "./layouts.js";
 import {
   AccessControlQuery,
@@ -254,6 +256,8 @@ export class Tbrv3 {
             deserializeResult(configQuery, evmAddressItem);
       else if (query.query === "AllowanceTokenBridge")
         deserializeResult(query, allowanceTokenBridgeReturnLayout);
+      else if (query.query === "GasToken")
+        deserializeResult(query, gasTokenReturnLayout);
       else if (query.query === "AccessControlQueries")
         for (const acquery of query.queries)
           if (acquery.query === "IsAdmin")
@@ -484,6 +488,8 @@ type RootQueryToResults<C extends RootQuery> =
   ? ConfigQueryResults<C["queries"]>
   : C extends { query: "AllowanceTokenBridge" }
   ? ArgsResult<C, AllowanceTokenBridgeReturn>
+  : C extends { query: "GasToken" }
+  ? ArgsResult<C, GasTokenReturn>
   : C extends { query: "AccessControlQueries" }
   ? AccessControlQueryResults<C["queries"]>
   : C extends { query: "Implementation" }

--- a/sdk/evm/tbrv3/layouts.ts
+++ b/sdk/evm/tbrv3/layouts.ts
@@ -115,6 +115,9 @@ export type AllowanceTokenBridgeReturn = LayoutToType<typeof allowanceTokenBridg
 export const gasTokenReturnLayout = evmAddressItem;
 export type GasTokenReturn = LayoutToType<typeof gasTokenReturnLayout>;
 
+export const gasTokenAllowanceTokenBridgeReturnLayout = layoutItems.amountItem;
+export type GasTokenAllowanceTokenBridgeReturn = LayoutToType<typeof gasTokenAllowanceTokenBridgeReturnLayout>;
+
 export const relayingFeeParamsLayout = [
   { name: "targetChain", ...supportedChainItem },
   { name: "gasDropoff",  ...gasDropoffItem     },
@@ -212,11 +215,12 @@ export const rootQueryLayout = {
   idSize: 1,
   idTag: "query",
   layouts: [
-    [[0x80, "RelayFee"            ], relayingFeeParamsLayout                     ],
-    [[0x81, "BaseRelayingConfig"  ], baseRelayingConfigParamsLayout              ],
-    [[0x82, "ConfigQueries"       ], subArrayLayout("queries", configQueryLayout)],
-    [[0x83, "AllowanceTokenBridge"], approveTokenLayout                          ],
-    [[0x84, "GasToken"            ], []                                          ],
+    [[0x80, "RelayFee"                    ], relayingFeeParamsLayout                     ],
+    [[0x81, "BaseRelayingConfig"          ], baseRelayingConfigParamsLayout              ],
+    [[0x82, "ConfigQueries"               ], subArrayLayout("queries", configQueryLayout)],
+    [[0x83, "AllowanceTokenBridge"        ], approveTokenLayout                          ],
+    [[0x84, "GasToken"                    ], []                                          ],
+    [[0x85, "GasTokenAllowanceTokenBridge"], []                                          ],
     ...accessControlQueryMap,
     ...implementationQueryLayout,
   ],

--- a/sdk/evm/tbrv3/layouts.ts
+++ b/sdk/evm/tbrv3/layouts.ts
@@ -1,6 +1,5 @@
-import type { Chain, CustomConversion, Layout, LayoutToType } from "@wormhole-foundation/sdk-base";
-import { layoutItems, type UniversalAddress } from "@wormhole-foundation/sdk-definitions";
-import { EvmAddress } from "@wormhole-foundation/sdk-evm";
+import type { CustomConversion, Layout, LayoutToType } from "@wormhole-foundation/sdk-base";
+import { layoutItems } from "@wormhole-foundation/sdk-definitions";
 import { gasDropoffItem } from "@xlabs-xyz/common-arbitrary-token-transfer";
 
 import { accessControlCommandMap, accessControlQueryMap } from "./solidity-sdk/access-control.js";
@@ -8,13 +7,10 @@ import { implementationQueryLayout, upgradeCommandLayout } from "./solidity-sdk/
 import { sweepTokensCommandLayout } from "./solidity-sdk/sweepTokens.js";
 import { evmAddressItem } from "./solidity-sdk/common.js";
 
-// TODO: update supported chains to the actual chains supported
-export const supportedChains = ["Ethereum", "Solana", "Arbitrum", "Base", "Sepolia", "BaseSepolia", "OptimismSepolia"] as const satisfies readonly Chain[];
-const supportedChainItem = layoutItems.chainItem({allowedChains: supportedChains});
-export type SupportedChain = typeof supportedChains[number];
+const supportedChainItem = layoutItems.chainItem();
 
 const peerChainItem = {
-  name: "chain", ...layoutItems.chainItem({ allowedChains: supportedChains }) 
+  name: "chain", ...layoutItems.chainItem()
 } as const;
 
 export const peerAddressItem = {

--- a/sdk/evm/tbrv3/layouts.ts
+++ b/sdk/evm/tbrv3/layouts.ts
@@ -116,6 +116,9 @@ export const approveTokenLayout = [
 export const allowanceTokenBridgeReturnLayout = layoutItems.amountItem;
 export type AllowanceTokenBridgeReturn = LayoutToType<typeof allowanceTokenBridgeReturnLayout>;
 
+export const gasTokenReturnLayout = evmAddressItem;
+export type GasTokenReturn = LayoutToType<typeof gasTokenReturnLayout>;
+
 export const relayingFeeParamsLayout = [
   { name: "targetChain", ...supportedChainItem },
   { name: "gasDropoff",  ...gasDropoffItem     },
@@ -217,6 +220,7 @@ export const rootQueryLayout = {
     [[0x81, "BaseRelayingConfig"  ], baseRelayingConfigParamsLayout              ],
     [[0x82, "ConfigQueries"       ], subArrayLayout("queries", configQueryLayout)],
     [[0x83, "AllowanceTokenBridge"], approveTokenLayout                          ],
+    [[0x84, "GasToken"            ], []                                          ],
     ...accessControlQueryMap,
     ...implementationQueryLayout,
   ],

--- a/sdk/evm/tbrv3/layouts.ts
+++ b/sdk/evm/tbrv3/layouts.ts
@@ -150,10 +150,10 @@ const configCommandLayout =
         peerChainItem,
         peerAddressItem
       ]],
-      [[ 0x01, "UpdateBaseFee"       ], [peerChainItem, { name: "value", ...baseFeeItem}]],
-      [[ 0x02, "UpdateMaxGasDropoff" ], [peerChainItem, { name: "value", ...gasDropoffItem }]],
+      [[ 0x01, "UpdateBaseFee"       ], [peerChainItem, { name: "value", ...baseFeeItem }]         ],
+      [[ 0x02, "UpdateMaxGasDropoff" ], [peerChainItem, { name: "value", ...gasDropoffItem }]      ],
       [[ 0x03, "UpdateTransferPause" ], [peerChainItem, { name: "value", ...layoutItems.boolItem }]],
-      [[ 0x0a, "UpdateFeeRecipient"  ], [{ name: "address",...evmAddressItem }]],
+      [[ 0x0a, "UpdateFeeRecipient"  ], [{ name: "address",...evmAddressItem }]                    ],
       // Only owner
       [[ 0x0b, "UpdateCanonicalPeer" ], [peerChainItem, peerAddressItem]],
     ]
@@ -165,13 +165,13 @@ export const configQueryLayout = {
   idSize: 1,
   idTag: "query",
   layouts: [
-    [[0x80, "IsChainSupported"], [peerChainItem]],
-    [[0x81, "IsChainPaused"   ], [peerChainItem]],
-    [[0x82, "BaseFee"         ], [peerChainItem]],
-    [[0x83, "MaxGasDropoff"   ], [peerChainItem]],
-    [[0x84, "CanonicalPeer"   ], [peerChainItem]],
+    [[0x80, "IsChainSupported"], [peerChainItem]                 ],
+    [[0x81, "IsChainPaused"   ], [peerChainItem]                 ],
+    [[0x82, "BaseFee"         ], [peerChainItem]                 ],
+    [[0x83, "MaxGasDropoff"   ], [peerChainItem]                 ],
+    [[0x84, "CanonicalPeer"   ], [peerChainItem]                 ],
     [[0x85, "IsPeer"          ], [peerChainItem, peerAddressItem]],
-    [[0x86, "FeeRecipient"    ], []],
+    [[0x86, "FeeRecipient"    ], []                              ],
   ],
 } as const satisfies Layout;
 export type ConfigQuery = LayoutToType<typeof configQueryLayout>;


### PR DESCRIPTION
With this, the gas token that was configured at init time can be queried from the contract.